### PR TITLE
Relicense (Apache-2.0 + Data-License 1.0); harden+speed sync; FAQ; 8 integration drafts

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Funding sources for understand-quickly. Lets users sponsor maintenance via
+# GitHub's "Sponsor" button. Removed entries are inactive — leave them blank.
+github: [looptech-ai]

--- a/.github/ISSUE_TEMPLATE/add-repo.yml
+++ b/.github/ISSUE_TEMPLATE/add-repo.yml
@@ -1,17 +1,31 @@
 name: Add my repo
-description: Request that your repo be indexed by understand-quickly.
+description: List your project in the understand-quickly registry — no code or PR required.
 title: "[add] <owner>/<repo>"
 labels: ["add-repo"]
 body:
   - type: markdown
     attributes:
       value: |
-        A PR is usually faster than an issue. See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md). Use this form only if you can't open one.
+        ## Welcome 👋
+
+        Use this form to add your repository to the registry. **No coding required** — fill the
+        fields below, submit, and a maintainer will open the PR for you (or auto-merge if your
+        project is on the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md)).
+
+        **Faster paths** if you're comfortable with them:
+
+        - 🖱️ [Wizard](https://looptech-ai.github.io/understand-quickly/add.html) — same fields, with auto-suggest and JSON preview.
+        - 💻 `npx @understand-quickly/cli add` — auto-detects everything from your repo.
+        - ✍️ Or open a PR directly per [CONTRIBUTING.md](https://github.com/looptech-ai/understand-quickly/blob/main/CONTRIBUTING.md).
+
+        ---
   - type: input
     id: id
     attributes:
       label: Repo id
-      description: Must match `owner/repo`.
+      description: |
+        Your project's `owner/repo` slug, exactly as it appears on GitHub.
+        For example, `looptech-ai/understand-quickly`.
       placeholder: yourname/yourrepo
     validations:
       required: true
@@ -19,10 +33,15 @@ body:
     id: format
     attributes:
       label: Graph format
+      description: |
+        Which tool did you run to generate your knowledge graph or context bundle?
+        If you're not sure, pick `generic@1` and a maintainer will help match the right one.
+        See [Supported formats](https://github.com/looptech-ai/understand-quickly#supported-formats) for setup links.
       options:
         - understand-anything@1
         - gitnexus@1
         - code-review-graph@1
+        - bundle@1
         - generic@1
     validations:
       required: true
@@ -30,7 +49,9 @@ body:
     id: graph_url
     attributes:
       label: graph_url
-      description: Must start with `https://`.
+      description: |
+        The public `https://` URL where the registry can fetch your graph.
+        Most users use a `raw.githubusercontent.com` URL for a JSON file in their default branch.
       placeholder: https://raw.githubusercontent.com/yourname/yourrepo/main/.understand-anything/knowledge-graph.json
     validations:
       required: true
@@ -38,22 +59,34 @@ body:
     id: description
     attributes:
       label: Description
-      description: One line, ≤ 200 chars.
+      description: |
+        One short sentence describing your project. Shows up in the registry table next to your repo.
+        Plain text only — please no markdown links or HTML.
+      placeholder: Multi-agent toolkit with built-in tracing, demos, and a Python sandbox.
     validations:
       required: true
   - type: input
     id: tags
     attributes:
       label: Tags
-      description: Comma-separated, optional.
-      placeholder: python, agents
+      description: |
+        Comma-separated keywords. Helps people discover your repo from the registry's search.
+      placeholder: python, agents, tracing
   - type: checkboxes
     id: instant_refresh
     attributes:
       label: Optional add-ons
       options:
-        - label: I'll also drop the publish workflow into my repo for instant-refresh on push.
+        - label: I'll also drop the publish workflow into my repo so the registry refreshes on every push.
   - type: markdown
     attributes:
       value: |
-        Reminder: a PR adding the entry to `registry.json` is faster than this form.
+        ---
+
+        ### What happens next
+
+        1. A maintainer (or our automation, for verified publishers) reads this issue and opens a PR adding your entry to `registry.json`.
+        2. CI fetches your `graph_url`, validates the JSON against the format schema, and (if green) merges.
+        3. Your repo shows up in the registry within a few minutes — no further action from you.
+
+        Typical turnaround: **same-day** for verified publishers, **24–48h** for first-time contributors. Stuck? Re-ping the issue or DM the maintainers — we don't bite.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,15 @@ contact_links:
   - name: Browse the registry
     url: https://looptech-ai.github.io/understand-quickly/
     about: See what's already indexed before opening a new issue.
-  - name: Add your repo (preferred path)
-    url: https://github.com/looptech-ai/understand-quickly/blob/main/CONTRIBUTING.md
-    about: A PR is faster than an issue for most additions.
+  - name: Add your repo via the wizard
+    url: https://looptech-ai.github.io/understand-quickly/add.html
+    about: Fill four fields; the bot opens the PR. Same as the issue form, with auto-suggest.
+  - name: Read the FAQ
+    url: https://github.com/looptech-ai/understand-quickly/blob/main/docs/faq.md
+    about: Plain-language answers to "What is this?" and "Should I add my repo?".
+  - name: Discussions
+    url: https://github.com/looptech-ai/understand-quickly/discussions
+    about: Open a question or share what you're building.
+  - name: Security report
+    url: https://github.com/looptech-ai/understand-quickly/security/advisories/new
+    about: Privately report a security issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@
 - [ ] `npm test` is green locally.
 - [ ] `npm run validate` is green (or the PR explains why a `graph_url` 404s in CI).
 - [ ] No third-party CDN added without a pinned version + integrity hash where possible.
-- [ ] No backend / always-on LLM dependency introduced — the registry stays a static-pointer service (see [How it works](../blob/main/README.md#how-it-works)).
+- [ ] No backend / always-on LLM dependency introduced — the registry stays a static-pointer service (see [How it works](../README.md#how-it-works)).
 - [ ] First-time contributor? Include a `Signed-off-by:` line per [DCO](https://developercertificate.org/), or note in the PR that you'd like help adding one.
 
 ## For non-technical contributors 👋

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,25 @@
 ## What
-<!-- one line: what does this PR change? -->
+<!-- One line: what does this PR change? -->
 
 ## Why
-<!-- the motivation; link an issue if relevant -->
+<!-- The motivation in 1-3 sentences. Link an issue if relevant. -->
+
+## Type of change
+<!-- Check all that apply. -->
+- [ ] **Registry entry** — adds or edits a row in `registry.json` for an existing format.
+- [ ] **New format** — adds a `schemas/<name>@<int>.json` plus `ok` / `bad` fixtures.
+- [ ] **Code / docs / tooling** — changes scripts, MCP, CLI, site, workflows, or docs.
 
 ## Checklist
-- [ ] If this adds a registry entry, the new `id` matches `owner/repo` and is unique.
-- [ ] If this adds a schema or fixture, ajv compiles + the `ok` fixture passes and the `bad` fixture fails.
-- [ ] `npm test` is green.
+<!-- Skip any that don't apply. -->
+- [ ] If this adds a registry entry: the new `id` matches `owner/repo` and is unique.
+- [ ] If this adds a schema or fixture: ajv compiles, the `ok` fixture validates, the `bad` fixture fails.
+- [ ] `npm test` is green locally.
 - [ ] `npm run validate` is green (or the PR explains why a `graph_url` 404s in CI).
-- [ ] No third-party CDN added without a pinned version.
-- [ ] No backend/LLM-on-registry dependency introduced — see [Zero cost](../blob/main/README.md#zero-cost).
+- [ ] No third-party CDN added without a pinned version + integrity hash where possible.
+- [ ] No backend / always-on LLM dependency introduced — the registry stays a static-pointer service (see [How it works](../blob/main/README.md#how-it-works)).
+- [ ] First-time contributor? Include a `Signed-off-by:` line per [DCO](https://developercertificate.org/), or note in the PR that you'd like help adding one.
+
+## For non-technical contributors 👋
+
+If this is your first PR, just fill in **What** and **Why**. A maintainer will help with anything else.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,39 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(actions)"
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+    commit-message:
+      prefix: "chore(deps)"
   - package-ecosystem: npm
     directory: /mcp
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+    commit-message:
+      prefix: "chore(deps-mcp)"
+  - package-ecosystem: npm
+    directory: /cli
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+    commit-message:
+      prefix: "chore(deps-cli)"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,60 @@
+name: CodeQL
+
+# GitHub-native security analysis. Runs on push to main, on PRs that touch
+# scanned source, and weekly to catch advisories published after merge.
+#
+# Languages covered: JavaScript/TypeScript (scripts/, mcp/, cli/, site/).
+# We do not scan vendored third-party assets under site/vendor/.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - "scripts/**"
+      - "mcp/src/**"
+      - "cli/**"
+      - "site/**"
+      - ".github/workflows/codeql.yml"
+  schedule:
+    - cron: "23 5 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript-typescript"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+          config: |
+            paths-ignore:
+              - site/vendor/**
+              - "**/node_modules/**"
+              - "**/dist/**"
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -85,5 +85,28 @@ jobs:
           CHANGED_IDS: ${{ steps.changed.outputs.changed_ids }}
         run: npm run validate
 
+      - name: Diagnostic banner
+        # Dump environment + tool versions before the test step so any future
+        # CI failure has obvious context in the log.
+        run: |
+          echo "::group::Environment"
+          echo "node: $(node --version)"
+          echo "npm: $(npm --version)"
+          echo "platform: $(uname -a)"
+          echo "cwd: $(pwd)"
+          echo "tmp writable: $(mktemp -d)"
+          echo "free disk:" && df -h . | tail -1
+          echo "::endgroup::"
+
       - name: Run unit + integration tests
-        run: npm test
+        run: npm test 2>&1 | tee /tmp/npm-test.log
+
+      - name: Dump test log on failure
+        if: failure()
+        run: |
+          echo "::group::npm test full log"
+          tail -200 /tmp/npm-test.log || true
+          echo "::endgroup::"
+          echo "::group::Failing test lines"
+          grep -E '^(not ok|# fail|Error:|TypeError:)' /tmp/npm-test.log || true
+          echo "::endgroup::"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,7 +25,64 @@ jobs:
           cache: 'npm'
       - run: npm ci
 
-      - name: Validate (full registry; CI scale fine at MVP size)
+      - name: Compute changed registry entry ids
+        id: changed
+        # Set CHANGED_IDS to the set of registry entry ids that changed in
+        # this PR's diff, OR leave it unset when schemas changed (so all
+        # entries get re-validated against the new shape). Code-only PRs
+        # with no registry.json or schema diff produce an empty set, which
+        # validate.mjs treats as "no entries to fetch" — keeps CI fast and
+        # immune to transient producer-URL flakiness.
+        run: |
+          set -e
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          git fetch --no-tags --depth=1 origin "$BASE_SHA" || true
+          DIFF=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" || true)
+          echo "Changed files:"
+          echo "$DIFF"
+          # If any schema changed, force a full validate.
+          if echo "$DIFF" | grep -q '^schemas/'; then
+            echo "Schema change detected — full validate (CHANGED_IDS unset)."
+            echo "full=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # If registry.json wasn't touched, no entries need re-fetching.
+          if ! echo "$DIFF" | grep -q '^registry.json$'; then
+            echo "No registry.json change and no schema change — skip per-entry validate."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # registry.json changed — extract added / modified entry ids.
+          IDS=$(git diff "$BASE_SHA" "$HEAD_SHA" -- registry.json \
+            | grep -E '^\+.*"id":' \
+            | sed -E 's/.*"id":[[:space:]]*"([^"]+)".*/\1/' \
+            | sort -u | paste -sd, -)
+          echo "Changed ids: $IDS"
+          echo "changed_ids=$IDS" >> "$GITHUB_OUTPUT"
+
+      - name: Validate registry shape (always)
+        # Pure schema check — no network. Catches any registry.json or
+        # meta.schema.json regression even when no entries are touched.
+        run: |
+          node -e "
+            import('./scripts/validate.mjs').then(async (m) => {
+              const fs = await import('node:fs');
+              const reg = JSON.parse(fs.readFileSync('registry.json', 'utf8'));
+              const r = m.validateRegistry(reg);
+              if (!r.ok) {
+                console.error('REGISTRY INVALID:');
+                for (const e of r.errors) console.error('  - ' + e.message);
+                process.exit(1);
+              }
+              console.log('Registry shape OK (' + reg.entries.length + ' entries).');
+            });
+          "
+
+      - name: Validate (per-entry fetch)
+        if: steps.changed.outputs.skip != 'true'
+        env:
+          CHANGED_IDS: ${{ steps.changed.outputs.changed_ids }}
         run: npm run validate
 
       - name: Run unit + integration tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,93 @@
 
 All notable changes to this project will be documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed (licensing — breaking for downstream re-use semantics)
+
+- **Code license switched from MIT to Apache License 2.0.** Adds an explicit
+  patent grant and contributor terms while remaining permissive. Copyright is
+  now joint **Alex Macdonald-Smith and LoopTech.AI**. New `NOTICE` file per
+  Apache convention.
+- **New Data License 1.0** in `DATA-LICENSE.md`. Governs registry data
+  (`registry.json`, schemas, aggregates, MCP responses, ingested third-party
+  graphs). Grants Users perpetual, sublicensable rights including AI/ML
+  training; in exchange, every User and Forker grants Alex Macdonald-Smith
+  and LoopTech.AI a perpetual, sublicensable back-grant. Producer
+  submissions carry an explicit ingestion grant. The Beneficiary back-grant
+  travels with any fork or extension.
+
+### Added (formats and integrations)
+
+- New `bundle@1` format for repo-context packers (Repomix, gitingest,
+  codebase-digest). Schema + fixtures + extractor support; bundle source-sha
+  sniffing accepts both `manifest.commit` and `metadata.commit` for
+  cross-format compatibility.
+- 8 new producer-side PR drafts under `docs/integrations/`:
+  graphify, codebase-memory-mcp, deepwiki-open (Wave 1, no schema dep);
+  repomix, gitingest, codebase-digest, pocketflow-tutorial-codebase-knowledge,
+  opendeepwiki (Wave 2, bundle@1 / generic@1).
+
+### Added (security and hardness)
+
+- **MCP**: SSRF guard on graph fetches blocking loopback, RFC1918, link-local
+  (incl. AWS/GCP `169.254.169.254`), unique-local IPv6, `*.internal` /
+  `*.local`. Schema-version assertion. Stale-cache fallback on registry 5xx.
+- **Sync**: atomic registry write (tmp + rename), deterministic id-sort
+  before write, wrapped legacy JSON parse, drift errors logged to stderr.
+- **Validate**: `CHANGED_IDS` env var validated against owner/repo regex with
+  a 1000-entry cap. Ajv `strict: 'log'`. Better validation error context
+  with format-specific schema link in the headline.
+- **Schemas**: tightened `meta.schema.json` `owner`/`repo` to
+  `^[A-Za-z0-9_.-]+$` with a 100-char cap.
+- **Aggregator**: per-fetch `AbortController` 30s timeout, `Content-Length`
+  pre-check + post-buffer cap at 50MB, label-tokenization cap at 256 chars.
+- **Issue parser**: replaced ReDoS-prone regex with O(n) split-based parser;
+  200k-char body cap.
+- **README rendering**: description sanitization (HTML-escape, strip
+  `javascript:` / `data:` / `vbscript:` / `file:` link schemes).
+- **Site**: `Content-Security-Policy` `<meta>` headers on `index.html`,
+  `add.html`, `about.html` — locks scripts to `'self'` + Cloudflare beacon,
+  blocks `frame-ancestors`, restricts `connect-src` to known endpoints.
+
+### Added (efficiency)
+
+- Memoized Ajv compilation + format-schema cache (test suite 4.0s → 2.7s).
+- Parallel aggregator fetches via bounded worker pool (concurrency=6) with
+  deterministic serial fold.
+
+### Added (UX for non-technical users and producers)
+
+- New plain-English [`docs/faq.md`](docs/faq.md) — "what is this?", "what's a
+  knowledge graph?", "what rights am I granting?", glossary.
+- New "New here?" section at the top of the README with a one-paragraph
+  pitch.
+- Status legend expanded with "What to do" column for each status.
+- Issue templates: rewritten add-repo form with friendlier copy, `bundle@1`
+  added to the format dropdown, plain-language hints per field, "what
+  happens next" footer with SLA expectations.
+- Issue config: extra contact links (wizard, FAQ, Discussions, security).
+- PR template: clearer change-type checklist, explicit DCO note, "for
+  non-technical contributors" footer.
+- Wizard (`add.html`): "View schema ↗" link next to every format, plain-language
+  format hints, expanded FAQ (license rights, SLA, format guide), updated
+  footer to Apache 2.0 + Data License 1.0.
+- CLI: top-level help shows examples and FAQ link; `add --help` lists
+  producer paths and schema folder hints; explicit Node-20-required check
+  with a friendly install pointer; error messages link to wizard / FAQ /
+  issue tracker.
+- Site footer: Apache 2.0 + Data License 1.0 links, FAQ link, direct link
+  to `meta.schema.json` (not the `schemas/` directory).
+
+### Added (GitHub repo polish)
+
+- New `CodeQL` workflow scanning JavaScript/TypeScript on push, PRs touching
+  scanned source, and weekly. Vendored `site/vendor/` excluded.
+- `FUNDING.yml` for GitHub Sponsors.
+- Dependabot updated: `/cli` directory now scanned (was missed); dev
+  dependencies grouped per ecosystem; `chore(actions|deps|deps-mcp|deps-cli)`
+  commit prefixes.
+
 ## [0.1.0] — 2026-05-07
 
 First public release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,26 @@ npm run render     # regenerate README table
 
 ---
 
-By contributing you agree your work is licensed under MIT. See [`LICENSE`](./LICENSE).
+## Licensing of contributions
+
+By submitting a contribution — whether code, docs, schemas, fixtures, or
+a registry entry pointing at a third-party graph — you agree to two
+things:
+
+1. **Code, docs, and schema contributions** are licensed under the
+   [Apache License 2.0](./LICENSE), and you are authorized to grant that
+   license. We follow [DCO](https://developercertificate.org/) sign-off
+   conventions: include `Signed-off-by: Your Name <you@example.com>` in
+   commits to confirm you have the right to submit your work.
+2. **Registry-data contributions** (entries that point at a `graph_url`,
+   `content_url`, or other Linked Artifact, plus any aggregated outputs
+   produced from them) are governed by the
+   [`DATA-LICENSE.md`](./DATA-LICENSE.md). In short: you grant Alex
+   Macdonald-Smith and LoopTech.AI a perpetual, royalty-free,
+   sublicensable right to use the submitted data — including for
+   AI/ML training and commercial products — and that grant travels with
+   any fork or extension of the registry. Read `DATA-LICENSE.md` before
+   submitting if you are doing so on behalf of an employer or you have
+   any doubt about your rights to the linked content.
 
 Please also read our [Code of Conduct](./CODE_OF_CONDUCT.md). We expect everyone interacting in issues, PRs, and discussions to follow it.

--- a/DATA-LICENSE.md
+++ b/DATA-LICENSE.md
@@ -1,0 +1,210 @@
+# Data Use License — Understand-Quickly Registry
+
+**Version 1.0 — effective 2026-05-08.**
+
+> **Plain-language summary.** The code in this repository is Apache-2.0
+> (see `LICENSE`). This document is a *separate* license that covers the
+> **data layer** of the registry: `registry.json`, the JSON schemas, the
+> aggregated stats, the MCP responses, the third-party graphs and bundles
+> that producers point at via `graph_url` / `content_url`, and any
+> derivative analytics. Anyone may use the registry data; in exchange,
+> Alex Macdonald-Smith and LoopTech.AI receive a permanent, broad data
+> license, and that grant travels with the data.
+>
+> **Not legal advice.** This document is a license offer. If you are
+> integrating this registry into a commercial product or otherwise need
+> certainty about your rights and obligations, consult your own counsel.
+
+---
+
+## 1. Definitions
+
+In this License:
+
+- **"Licensor"** means Alex Macdonald-Smith, an individual, and LoopTech.AI,
+  jointly. The Licensor is also a Beneficiary (see §3).
+- **"Beneficiaries"** means Alex Macdonald-Smith and LoopTech.AI, including
+  their respective successors, assigns, affiliates under common control,
+  and authorized contractors acting on their behalf.
+- **"Registry"** means the software, services, schemas, and data products
+  comprising or derived from `looptech-ai/understand-quickly`, any fork
+  thereof, and any deployment of either.
+- **"Registry Data"** means, collectively:
+  - the contents of `registry.json` (the entry list, status fields, drift
+    fields, per-entry stats);
+  - the JSON schemas under `schemas/` and their fixtures;
+  - any aggregated statistics, indexes, concept lists, or analytics
+    produced from registry contents (e.g., `site/stats.json`);
+  - any response payloads emitted by the Registry's MCP server or HTTP
+    endpoints;
+  - any **Producer Submission** (see §4), including without limitation any
+    third-party knowledge graph, repo-context bundle, file manifest, or
+    metadata fetched via a `graph_url`, `content_url`, or equivalent
+    pointer registered with the Registry, and any cached, transformed,
+    or summarized form thereof.
+- **"Producer"** means any person or entity that submits an entry, opens a
+  pull request, fires a `repository_dispatch`, or otherwise causes data
+  to be ingested into the Registry.
+- **"User"** means any person or entity who accesses, downloads, queries,
+  forks, hosts, or otherwise uses the Registry or any Registry Data.
+- **"Forker"** means any User who runs, hosts, redistributes, or operates
+  a copy, derivative, or extension of the Registry, in whole or in part.
+
+## 2. License grant to Users
+
+Subject to §§ 3–6, the Licensor grants every User a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, sublicensable license to:
+
+(a) access, query, and download Registry Data;
+
+(b) reproduce, redistribute, and publicly display Registry Data;
+
+(c) prepare, distribute, and publish derivative analyses, indexes,
+    aggregations, summaries, embeddings, and machine-learning training
+    artifacts based on Registry Data;
+
+(d) use Registry Data to train, fine-tune, evaluate, retrieve-augment, or
+    ground any artificial-intelligence or machine-learning system; and
+
+(e) commercialize the foregoing.
+
+This grant is automatically extended, with the same scope, to **anyone
+who uses any copy, fork, mirror, or extension of the Registry** — i.e.,
+the User-side rights travel with the data. A Forker MUST NOT impose
+restrictions on downstream Users that would narrow this §2 grant.
+
+## 3. License grant to Beneficiaries (back-grant)
+
+In consideration of the §2 grant, every User and Forker grants the
+**Beneficiaries** a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable, sublicensable license to do all of the
+following with respect to Registry Data and any modifications,
+extensions, additions, derivative works, or new datasets that the User
+or Forker creates by combining with, extending, or operating a copy of
+the Registry (collectively, "Forker Data"):
+
+(a) the rights enumerated in §2(a)–(e);
+
+(b) the right to incorporate Forker Data into the upstream Registry, into
+    Beneficiary products and services (including commercial products),
+    and into Beneficiary AI/ML training corpora; and
+
+(c) the right to sublicense any of the foregoing to third parties on
+    terms of the Beneficiaries' choosing.
+
+This back-grant is a condition of operating, hosting, or extending the
+Registry. A Forker who does not wish to grant these rights MUST NOT
+operate, host, fork, mirror, or otherwise extend the Registry.
+
+The back-grant survives termination of the User's or Forker's use.
+
+## 4. Producer submission grant
+
+When a Producer submits an entry to the Registry — by opening a pull
+request against `registry.json`, by firing a `repository_dispatch` event,
+by using `npx @understand-quickly/cli add`, or by any equivalent means —
+the Producer represents and warrants that they have the right to submit
+the linked content and grants the **Beneficiaries** and all **Users**
+(per §§ 2 and 3) the rights described in this License with respect to:
+
+(a) the graph, bundle, manifest, or other artifact at the registered
+    `graph_url` or `content_url` (a "Linked Artifact");
+
+(b) all metadata associated with the Linked Artifact, including without
+    limitation `metadata.commit`, `metadata.tool_version`,
+    `metadata.generated_at`, `metadata.tool`, the file list, and any
+    embedded structural data;
+
+(c) any future revisions of the Linked Artifact at the same URL during
+    the period the entry remains in the Registry; and
+
+(d) any derived form (cached copies, schema-validated subsets,
+    aggregated statistics, concept indexes, search shards) the Registry
+    or its Forkers create from (a)–(c).
+
+A Producer who lacks rights to grant (a)–(d) for the underlying content
+MUST NOT submit it to the Registry. A Producer may withdraw an entry
+prospectively at any time by opening a removal PR or by setting the
+entry's `status` to `revoked`; withdrawal does not retroactively rescind
+rights already exercised in good faith by Beneficiaries or Users.
+
+## 5. Inheritance and viral data terms
+
+This License is intended to be **viral with respect to data flow**:
+
+- Any redistribution of Registry Data, in any form, MUST be accompanied
+  by a copy of (or hyperlink to) this License.
+- Any fork, mirror, derivative, or extension of the Registry MUST keep
+  this `DATA-LICENSE.md` file (or an equivalent successor document
+  granting at least the same rights to Beneficiaries) in place.
+- Any service, product, or AI system built on Registry Data MUST not
+  attempt to nullify, contractually exclude, or technically frustrate
+  §3 (the Beneficiary back-grant). For example, a Forker MAY NOT operate
+  a private deployment that scrapes Registry Data, modifies it, and
+  refuses Beneficiaries access to the modifications.
+
+## 6. Disclaimers; relationship to other licenses
+
+(a) **No warranty.** Registry Data is provided "AS IS", without warranty
+    of any kind. The Licensor and the Beneficiaries make no
+    representation as to accuracy, completeness, fitness for a particular
+    purpose, non-infringement, or freedom from defects. Users assume all
+    risk of use.
+
+(b) **No endorsement of upstream tools.** The Registry indexes
+    third-party tools and their outputs. Inclusion of a tool, repo, or
+    Linked Artifact in the Registry does not imply endorsement, audit,
+    or vouching for security, quality, or licensing posture by the
+    Licensor or Beneficiaries.
+
+(c) **Code license.** This License does not modify the Apache License,
+    Version 2.0 that governs the source code in `LICENSE`. The two
+    documents are read together; in the event of irreconcilable
+    conflict, the Apache License governs as to code, and this License
+    governs as to Registry Data.
+
+(d) **Upstream licenses preserved.** Each Linked Artifact may also be
+    governed by the license of its upstream repository. Nothing in this
+    License purports to override that upstream license; this License
+    operates only on the Producer's submission act and on derivatives
+    created by the Registry. Users should consult the upstream license
+    of any Linked Artifact before relying on it for purposes outside
+    the §2 grant.
+
+(e) **Termination for misuse.** The Licensor may terminate a specific
+    User's or Forker's §2 rights upon written notice if that User or
+    Forker materially breaches §3 or §5. Termination does not affect
+    rights of unrelated Users or the §3 back-grant already vested in
+    Beneficiaries.
+
+(f) **Severability.** If any provision is held unenforceable, the
+    remaining provisions remain in full force.
+
+(g) **Governing law.** This License is governed by the laws of the
+    Province of Ontario, Canada, and the federal laws of Canada
+    applicable therein, without regard to conflict-of-laws rules.
+
+---
+
+## 7. How to comply (quick checklist)
+
+If you are a **User** querying or downloading the Registry: nothing to
+do — you already have the §2 rights.
+
+If you are a **Producer** adding an entry:
+
+- [ ] You have the right to submit the linked graph/bundle.
+- [ ] You accept the §4 grant on submission.
+- [ ] You may withdraw entries you control at any time.
+
+If you are a **Forker** running a copy:
+
+- [ ] Keep this `DATA-LICENSE.md` (or equivalent) in your fork.
+- [ ] Don't strip or contractually narrow the §3 back-grant.
+- [ ] Pass §2 rights through to your downstream users.
+
+---
+
+*Questions or licensing concerns: open an issue on
+[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly/issues)
+or contact LoopTech.AI directly.*

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,215 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 Alex Macdonald-Smith
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Alex Macdonald-Smith and LoopTech.AI
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   ---
+
+   ADDITIONAL TERMS — DATA USE AND REGISTRY DATA GRANT
+
+   This software is distributed together with a separate, supplemental
+   data-use grant set out in the file DATA-LICENSE.md at the root of
+   this repository. The Apache License above governs the Source and
+   Object code; DATA-LICENSE.md governs Registry Data (as defined
+   therein), including third-party graphs and bundles ingested by the
+   registry, and grants additional rights to Alex Macdonald-Smith and
+   LoopTech.AI. Both documents apply; in case of conflict between them,
+   DATA-LICENSE.md governs as to Registry Data and this Apache License
+   governs as to code.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,20 @@
+Understand-Quickly Registry
+Copyright 2026 Alex Macdonald-Smith and LoopTech.AI
+
+This product includes software developed by Alex Macdonald-Smith and
+LoopTech.AI (https://looptech.ai). It is licensed under the Apache
+License, Version 2.0 (see LICENSE) for code, and under the supplemental
+DATA-LICENSE.md for Registry Data, ingested third-party graphs, and
+derived data products (registry.json, aggregates, MCP responses,
+schema validation outputs, etc.).
+
+Portions of the source schemas, fixtures, and integration drafts
+reference upstream tools (Understand-Anything, GitNexus,
+code-review-graph, Repomix, gitingest, codebase-digest, deepwiki-open,
+graphify, codebase-memory-mcp, PocketFlow-Tutorial-Codebase-Knowledge,
+OpenDeepWiki) — those projects retain their own copyrights and
+licenses; this NOTICE does not extend to them.
+
+Vendored third-party assets:
+  - vis-network (Apache-2.0), vendored under site/vendor/
+  - Cloudflare Web Analytics (CC-BY snippet)

--- a/README.md
+++ b/README.md
@@ -15,9 +15,23 @@ Point AI agents at any indexed repo and they get a current, schema-validated gra
 [![issues](https://img.shields.io/github/issues/looptech-ai/understand-quickly)](https://github.com/looptech-ai/understand-quickly/issues)
 [![last commit](https://img.shields.io/github/last-commit/looptech-ai/understand-quickly)](https://github.com/looptech-ai/understand-quickly/commits/main)
 
-[**Browse →**](https://looptech-ai.github.io/understand-quickly/) · [**Add your repo (wizard)**](https://looptech-ai.github.io/understand-quickly/add.html) · [**Quickstart**](#quickstart) · [**Contributing**](CONTRIBUTING.md)
+[**Browse →**](https://looptech-ai.github.io/understand-quickly/) · [**Add your repo (wizard)**](https://looptech-ai.github.io/understand-quickly/add.html) · [**Quickstart**](#quickstart) · [**FAQ (plain English)**](docs/faq.md) · [**Contributing**](CONTRIBUTING.md)
 
 </div>
+
+---
+
+## New here? Read this first 👋
+
+**It's a public directory of "map files" for codebases.** Each entry points at a JSON file (a *knowledge graph* or *context bundle*) that describes a project's structure — files, functions, modules, how they connect — in a shape that AI tools can read in one network request.
+
+If you're a **project maintainer**, you can add your repo so AI assistants can understand it instantly. If you're an **AI agent or tooling developer**, you can fetch any indexed graph by URL with no auth and no SDK.
+
+- **No code required to be listed.** Use the [wizard](https://looptech-ai.github.io/understand-quickly/add.html) — fill four fields, the bot opens the PR.
+- **No infrastructure, no costs.** Graphs stay in your repo; we only store pointers.
+- **Open and public.** Apache 2.0 code; permissive [Data License](DATA-LICENSE.md) for the registry.
+
+> First time? The [FAQ](docs/faq.md) answers "what is a knowledge graph?", "do I need this?", and "what happens after I submit?" in plain language.
 
 ---
 
@@ -145,16 +159,19 @@ Drop [`docs/publish-template.yml`](docs/publish-template.yml) into your repo as 
 
 ## Status legend
 
-| Emoji | Status | Meaning |
-| :---: | --- | --- |
-| 🆕 | `pending` | registered but not yet synced |
-| ✅ | `ok` | fetched, validated, current |
-| 🟡 | `missing` | 404 in last sync (will retry) |
-| ⚠️ | `invalid` | body failed schema validation |
-| 📦 | `oversize` | graph > 50 MB; not fetched |
-| 🔁 | `transient_error` | network / 5xx; retried |
-| 💀 | `dead` | 7+ consecutive misses |
-| ↪️ | `renamed` | superseded by `renamed_to` |
+Each entry's `status` field tells consumers whether the linked graph is currently usable.
+
+| Emoji | Status | Meaning | What to do |
+| :---: | --- | --- | --- |
+| 🆕 | `pending` | Registered but the registry hasn't synced it yet. | Wait for the next sync (≤24h, or fire `repository_dispatch` for instant). |
+| ✅ | `ok` | Fetched, validated, current. | Use it. |
+| 🟡 | `missing` | 404 in the last sync. Will keep retrying. | Verify the file exists at the registered URL on the default branch. |
+| ⚠️ | `invalid` | Body failed schema validation. | Run `npm run validate` locally; fix the field that fails. |
+| 📦 | `oversize` | Graph exceeds 50 MB; not fetched. | Slim the graph or split it. |
+| 🔁 | `transient_error` | Network or 5xx; will retry next sync. | Usually nothing — wait one cycle. |
+| 💀 | `dead` | 7+ consecutive misses. | Re-publish or open an issue to remove the entry. |
+| ↪️ | `renamed` | Superseded by `renamed_to`. | Update tooling to point at the new id. |
+| 🚫 | `revoked` | Maintainer-retracted. | Don't consume; contact maintainers if unexpected. |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Point AI agents at any indexed repo and they get a current, schema-validated gra
 [![sync](https://github.com/looptech-ai/understand-quickly/actions/workflows/sync.yml/badge.svg)](https://github.com/looptech-ai/understand-quickly/actions/workflows/sync.yml)
 [![pages](https://github.com/looptech-ai/understand-quickly/actions/workflows/pages.yml/badge.svg)](https://looptech-ai.github.io/understand-quickly/)
 [![release](https://img.shields.io/github/v/release/looptech-ai/understand-quickly?label=release&sort=semver)](https://github.com/looptech-ai/understand-quickly/releases)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Data License](https://img.shields.io/badge/Data%20License-UQ--Data%201.0-orange.svg)](DATA-LICENSE.md)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![issues](https://img.shields.io/github/issues/looptech-ai/understand-quickly)](https://github.com/looptech-ai/understand-quickly/issues)
 [![last commit](https://img.shields.io/github/last-commit/looptech-ai/understand-quickly)](https://github.com/looptech-ai/understand-quickly/commits/main)
@@ -174,4 +175,6 @@ npm run render     # regenerate README table
 
 ## License
 
-MIT © 2026 Alex Macdonald-Smith. See [LICENSE](LICENSE).
+- **Code** — [Apache License 2.0](LICENSE) © 2026 Alex Macdonald-Smith and LoopTech.AI. Includes a patent grant and contributor terms.
+- **Registry data** — [Understand-Quickly Data License 1.0](DATA-LICENSE.md). Anyone can use the registry, including for AI/ML training; in exchange, contributions and submissions grant Alex Macdonald-Smith and LoopTech.AI a perpetual, sublicensable data-use right that travels with any fork or extension. See [`DATA-LICENSE.md`](DATA-LICENSE.md) for the full terms.
+- **NOTICE** file: [`NOTICE`](NOTICE).

--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,21 +1,184 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 Alex Macdonald-Smith
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Alex Macdonald-Smith and LoopTech.AI
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0

--- a/cli/bin/understand-quickly.mjs
+++ b/cli/bin/understand-quickly.mjs
@@ -4,20 +4,46 @@
 import { runAdd, helpText } from '../src/add.mjs';
 
 const TOPLEVEL_HELP = [
-  '@understand-quickly/cli',
+  '@understand-quickly/cli — list your repo in the public registry of code-knowledge graphs.',
   '',
   'Usage:',
   '  understand-quickly <command> [flags]',
   '',
   'Commands:',
-  '  add        register your repo with the understand-quickly registry',
+  '  add        register your repo (auto-detects id / format / graph file)',
   '  help       show help for the CLI or a specific command',
+  '',
+  'Examples:',
+  '  understand-quickly add               # interactive, run from your repo',
+  '  understand-quickly add --open-issue  # auto-open a prefilled GitHub issue',
+  '  understand-quickly add --print-entry # print the JSON; do nothing else',
+  '',
+  'New here? Start with the FAQ (plain-English):',
+  '  https://github.com/looptech-ai/understand-quickly/blob/main/docs/faq.md',
   '',
   'Run `understand-quickly add --help` for `add`-specific flags.',
   ''
 ].join('\n');
 
+function ensureNodeVersion() {
+  // Engines pins >=20; npm/npx will warn but still attempt to run on older
+  // Node. Surface a friendly message so a non-technical user gets a clear
+  // path-forward instead of a cryptic `import.meta` or top-level-await error.
+  const m = /^v(\d+)/.exec(process.version);
+  const major = m ? parseInt(m[1], 10) : 0;
+  if (major < 20) {
+    process.stderr.write(
+      `understand-quickly requires Node.js 20 or newer. ` +
+      `You are running ${process.version}.\n` +
+      `Install Node 20+ from https://nodejs.org/ or use nvm:\n` +
+      `  nvm install 20 && nvm use 20\n`
+    );
+    process.exit(1);
+  }
+}
+
 async function main() {
+  ensureNodeVersion();
   const argv = process.argv.slice(2);
   const cmd = argv[0];
 
@@ -48,5 +74,11 @@ main()
   .then(code => { process.exit(code || 0); })
   .catch(err => {
     process.stderr.write(`error: ${err.message}\n`);
+    process.stderr.write(
+      `\nIf this error doesn't make sense, try:\n` +
+      `  - The wizard: https://looptech-ai.github.io/understand-quickly/add.html\n` +
+      `  - The FAQ:    https://github.com/looptech-ai/understand-quickly/blob/main/docs/faq.md\n` +
+      `  - Open an issue: https://github.com/looptech-ai/understand-quickly/issues/new/choose\n`
+    );
     process.exit(1);
   });

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@understand-quickly/cli",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "bin": {
         "understand-quickly": "bin/understand-quickly.mjs"
       },

--- a/cli/package.json
+++ b/cli/package.json
@@ -26,8 +26,11 @@
     "mcp",
     "cli"
   ],
-  "license": "MIT",
+  "license": "Apache-2.0",
   "author": "Alex Macdonald-Smith <Alex.Mac@LoopTech.AI>",
+  "contributors": [
+    "LoopTech.AI <https://looptech.ai>"
+  ],
   "homepage": "https://github.com/looptech-ai/understand-quickly/tree/main/cli",
   "repository": {
     "type": "git",

--- a/cli/src/add.mjs
+++ b/cli/src/add.mjs
@@ -23,6 +23,7 @@ const KNOWN_FORMATS = [
   'understand-anything@1',
   'gitnexus@1',
   'code-review-graph@1',
+  'bundle@1',
   'generic@1'
 ];
 
@@ -228,7 +229,23 @@ function printDiff(entry, registry) {
 
 function helpText() {
   return [
-    'understand-quickly add — register your repo with the understand-quickly registry.',
+    'understand-quickly add — list your repo in the public registry.',
+    '',
+    'What it does:',
+    '  Auto-detects your repo id, default branch, and existing knowledge-graph file.',
+    '  Prints the registry entry it would submit, then offers to either:',
+    '    • open a prefilled GitHub issue (no PR skills needed), or',
+    '    • open a PR via `gh` if you have it installed.',
+    '',
+    'Quickstart (run inside a git repo with a knowledge-graph file already committed):',
+    '  npx @understand-quickly/cli add',
+    '',
+    'Don\'t have a graph file yet? Pick a producer first:',
+    '  - Understand-Anything → .understand-anything/knowledge-graph.json',
+    '  - GitNexus            → .gitnexus/graph.json',
+    '  - code-review-graph   → .crg/graph.json',
+    '  - Repomix / gitingest → write a bundle@1 sidecar; see docs/integrations/protocol.md',
+    '  - any custom tool     → emit {nodes, edges} JSON; pick generic@1',
     '',
     'Usage:',
     '  npx @understand-quickly/cli add [flags]',
@@ -236,8 +253,9 @@ function helpText() {
     'Flags:',
     '  --id <owner/repo>          override auto-detected id',
     '  --format <name>@<int>      override sniffed format',
+    '                             (' + KNOWN_FORMATS.join(', ') + ')',
     '  --graph-url <url>          override computed graph URL',
-    '  --description "<text>"     one-line description',
+    '  --description "<text>"     one-line description (max 200 chars)',
     '  --tags a,b,c               tags as comma-separated list',
     '  --print-entry              print the entry JSON, exit (default in non-TTY)',
     '  --open-issue               open a prefilled GitHub issue in the browser',
@@ -245,6 +263,10 @@ function helpText() {
     '  --registry <owner/repo>    override registry repo (default: ' + DEFAULT_REGISTRY + ')',
     '  --cwd <path>               run as if from this directory',
     '  --help                     show this help',
+    '',
+    'Stuck or non-technical?',
+    '  Use the wizard at https://looptech-ai.github.io/understand-quickly/add.html',
+    '  or the FAQ at https://github.com/looptech-ai/understand-quickly/blob/main/docs/faq.md',
     ''
   ].join('\n');
 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,116 @@
+# FAQ — understand-quickly in plain English
+
+> If you're new here, start with this page. It answers "what is it?" and "should I bother?" without assuming you've used MCP, JSON Schema, or AI agents before.
+
+## What is understand-quickly?
+
+It's a public **directory of code-knowledge graphs** — small JSON files that describe what's in a codebase (files, functions, modules, how they connect).
+
+Think of it like an awesome-list, but instead of listing repos, it lists *map files of repos* that AI assistants can read in one network request.
+
+## Who is this for?
+
+- **Project maintainers** who want their repo to be easier for AI tools to understand.
+- **AI agents and IDE plugins** (Claude, Cursor, Codex, custom MCP servers) that need fresh, structured context about a codebase before they can be helpful.
+- **Researchers** comparing tools that emit code graphs (Understand-Anything, GitNexus, Repomix, gitingest, etc.).
+- **Anyone** who wants a one-click way to point an AI at a real codebase.
+
+## What's a "code-knowledge graph"?
+
+A JSON file that lists the important pieces of a project (files, classes, functions, concepts) and the relationships between them ("file A imports file B", "function X calls function Y"). It's something a generator tool produces from your source code — you don't write it by hand.
+
+If you've heard of [Repomix](https://github.com/yamadashy/repomix) or [gitingest](https://github.com/cyclotruc/gitingest), those produce a similar idea but as packed text rather than a graph; the registry indexes both kinds.
+
+## Do I need to install anything to use the registry?
+
+No. The registry is a public JSON file. Anyone — agent or human — can read it with one fetch:
+
+```
+https://looptech-ai.github.io/understand-quickly/registry.json
+```
+
+Or browse it visually at <https://looptech-ai.github.io/understand-quickly/>.
+
+## How do I add my project?
+
+Easiest paths, in order of effort:
+
+1. **Wizard** — fill four fields at <https://looptech-ai.github.io/understand-quickly/add.html>; the bot opens the PR.
+2. **CLI** — `npx @understand-quickly/cli add` from inside your repo.
+3. **Issue** — open the [Add my repo](https://github.com/looptech-ai/understand-quickly/issues/new?template=add-repo.yml) issue template; a maintainer translates it into a PR.
+4. **Direct PR** — fork, append an entry to `registry.json`, open a PR. See [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+You need a **knowledge graph file in your repo first**. Run any [supported tool](../README.md#supported-formats) — most have a one-line install.
+
+## How long until my repo is indexed?
+
+- **Verified publishers** (allowlisted maintainers): the PR auto-merges within minutes once CI passes.
+- **First-time contributors**: 24–48h is typical.
+- After the PR merges, the registry's nightly sync (or your instant-refresh workflow) picks up new commits to your graph file.
+
+## Does it cost anything?
+
+No. The registry is free to use, free to be listed in, and there's no premium tier. The infrastructure is GitHub Pages + GitHub Actions; we deliberately have no servers and no LLM costs.
+
+## What can I actually do with the registry?
+
+A few common patterns:
+
+- **From an AI agent (curl):** fetch `registry.json`, pick an entry, fetch its `graph_url`. Now your agent has structured info about that codebase.
+- **From Claude / Cursor / Codex:** install our [MCP server](../mcp/README.md). Tools like `find_graph_for_repo`, `get_graph`, and `search_concepts` become available inside your AI assistant.
+- **From your own code:** the registry is a stable JSON API; build whatever you want on top.
+
+## Why would I want to be in the registry?
+
+- **Discoverability.** AI agents looking for context about a class of project — Python ML libraries, TypeScript CLIs, Rust web frameworks, whatever — find yours.
+- **Free hosting of the metadata.** The graph file stays in your repo; the registry only stores a pointer.
+- **Drift detection.** If your graph file falls behind your default branch, the registry surfaces that publicly so consumers know.
+- **Zero lock-in.** It's just a JSON entry pointing at a JSON file in your repo. Remove your entry any time.
+
+## What's the difference between the formats (`understand-anything@1`, `gitnexus@1`, `bundle@1`, …)?
+
+Each format is a different shape of knowledge graph, produced by a different tool:
+
+| Format | What it looks like | Best for |
+| --- | --- | --- |
+| `understand-anything@1` | Code-elements + concepts graph | General code understanding |
+| `gitnexus@1` | Git-aware graph with PR-change tracking | Active development workflows |
+| `code-review-graph@1` | Files / classes / tests with review hooks | PR review automation |
+| `bundle@1` | Pointer to a packed-text repo dump (Repomix, gitingest, codebase-digest) | Whole-repo context for LLMs |
+| `generic@1` | Any `{nodes, edges}` graph | Custom tools / fallback |
+
+If you're not sure which to pick, run any of the linked tools — whichever output format matches their tool's name is the right one.
+
+## Is my data private?
+
+The registry is **public** by design. Don't add a private repo or anything you wouldn't post on GitHub. The graph files you point at must be publicly fetchable too.
+
+By submitting an entry, you grant the rights described in [`DATA-LICENSE.md`](../DATA-LICENSE.md). In short: anyone (including AI training pipelines) can use the registry, and the registry maintainers (Alex Macdonald-Smith / LoopTech.AI) get a perpetual right to use submitted data — that grant travels with any fork. If your linked content is on a license that restricts that, please don't submit it.
+
+## I don't write code — can I still help?
+
+Yes. A few non-code ways to contribute:
+
+- **Submit your project** via the wizard or issue form (no PR skills needed).
+- **Translate the docs** — open an issue if you want to take a language.
+- **Improve this FAQ** — what was confusing when you arrived?
+- **Star and share** — adoption is the only real currency for a registry.
+
+## I'm stuck. Where do I get help?
+
+- 💬 [Discussions](https://github.com/looptech-ai/understand-quickly/discussions) — open-ended questions.
+- 🐛 [Issues](https://github.com/looptech-ai/understand-quickly/issues) — bugs and feature requests.
+- 🛡️ [Security advisories](https://github.com/looptech-ai/understand-quickly/security/advisories/new) — for security reports.
+
+We answer everything; if you don't hear back in a couple of days, ping the issue and we'll bump it.
+
+## Glossary
+
+- **Registry** — the JSON file (`registry.json`) listing all indexed projects.
+- **Entry** — one row in the registry, pointing at one project's graph file.
+- **Format** — the shape of the graph file (e.g., `understand-anything@1`). Each format has a JSON Schema in `schemas/`.
+- **Producer** — a tool that emits a graph in one of the supported formats.
+- **Consumer** — anything that reads the registry: an AI agent, an MCP client, a research script.
+- **Drift** — when your graph file is behind your default branch (i.e., out of date).
+- **MCP** — [Model Context Protocol](https://modelcontextprotocol.io). The way AI assistants like Claude integrate with external tools/data.
+- **Verified publisher** — a maintainer whose registry-only PRs auto-merge after CI passes.

--- a/docs/integrations/_template.md
+++ b/docs/integrations/_template.md
@@ -50,6 +50,8 @@ A drop-in CI workflow snippet lives at [`docs/integrations/sample-publish-workfl
 - The registry is in early adoption; this integration is opt-in for early users. Nothing breaks if you don't merge — users can still register manually via the wizard or CLI.
 - For a path to auto-merge of registry updates from `<TOOL>`, see the [verified publisher process](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md).
 
+- **What this means licensing-wise for your users.** Submitting via `--publish` is governed by the [Understand-Quickly Data License 1.0](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) — see [protocol §10](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#10-licensing-of-submitted-data). It is opt-in, gated on the user setting `UNDERSTAND_QUICKLY_TOKEN`; consider mirroring this paragraph in your own `--publish` documentation so users know what they are consenting to.
+
 ## Links
 
 - Registry: <https://github.com/looptech-ai/understand-quickly>

--- a/docs/integrations/code-review-graph-pr.md
+++ b/docs/integrations/code-review-graph-pr.md
@@ -52,6 +52,8 @@ A drop-in workflow snippet lives at [`docs/integrations/sample-publish-workflow.
 - The registry is in early adoption; this is opt-in for early users. Nothing in code-review-graph's existing surface needs to break.
 - Once code-review-graph has shipped this and a few users land in the registry, we can add `tirth8205/code-review-graph` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge of registry updates.
 
+- **What this means licensing-wise for your users.** Submitting via `--publish` is governed by the [Understand-Quickly Data License 1.0](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) — see [protocol §10](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#10-licensing-of-submitted-data). It is opt-in, gated on the user setting `UNDERSTAND_QUICKLY_TOKEN`; consider mirroring this paragraph in your own `--publish` documentation so users know what they are consenting to.
+
 ## Links
 
 - Registry: <https://github.com/looptech-ai/understand-quickly>

--- a/docs/integrations/codebase-digest-pr.md
+++ b/docs/integrations/codebase-digest-pr.md
@@ -1,0 +1,69 @@
+# PR draft — codebase-digest → understand-quickly
+
+Target repo: [`kamilstanuch/codebase-digest`](https://github.com/kamilstanuch/codebase-digest)
+
+Paste the body below into the PR description on that repo. The author should confirm the exact CLI invocation (`codebase-digest`, `python -m codebase_digest`, etc.) and the conventional output filename (this draft assumes `codebase-digest.txt` for the body and a sidecar `.codebase-digest/digest.bundle.json` for the registry pointer). The rest is repo-agnostic.
+
+---
+
+## Title
+
+`Add --publish flag for understand-quickly registry integration`
+
+## Why
+
+[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public registry of code-knowledge **and** code-context artifacts that ships an MCP server and a stable `registry.json` API. codebase-digest is a top-of-mind packer + analyzer in the AI-dev ecosystem; the registry's [`bundle@1`](https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json) format indexes its digest output natively and surfaces its analyzer metrics (`file_count`, `byte_count`, `token_estimate`) in the registry table.
+
+Wiring a `--publish` flag means any user who runs codebase-digest can land in the registry with one flag, and AI agents (Claude, Codex, Cursor via MCP) can resolve a repo URL to its digest via the registry's `find_graph_for_repo` tool — with the analyzer metrics already populated in the registry entry.
+
+- **Discoverability.** Every published digest appears at <https://looptech-ai.github.io/understand-quickly/>.
+- **No infrastructure on our side.** The plaintext digest stays in the user's repo; the registry only stores a small JSON pointer (`bundle@1` manifest).
+- **Agent-consumable.** MCP clients fetch the digest through the registry without each user maintaining a private mapping.
+
+## What changes
+
+- Add a `--publish` flag (or equivalent — `--register`, `--publish-to-uq`) to the codebase-digest CLI.
+- After the existing digest + analysis step, when `--publish` is set:
+  1. Write a small JSON sidecar at `.codebase-digest/digest.bundle.json` that conforms to the registry's [`bundle@1`](https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json) schema. The sidecar carries `manifest.tool = "codebase-digest"`, `tool_version`, `generated_at`, `commit`, `file_count`, `byte_count`, `token_estimate`, `format = "plaintext"`, and `content_url` pointing at the existing digest in the same repo. The analyzer metrics codebase-digest already computes map directly onto these fields.
+  2. If `$UNDERSTAND_QUICKLY_TOKEN` is set, fire a `repository_dispatch` event at `looptech-ai/understand-quickly`. Otherwise, write the sidecar locally and exit cleanly.
+- If the user's repo isn't yet in the registry, print a friendly one-liner pointing at `npx @understand-quickly/cli add` or the wizard and exit cleanly — don't fail the parent run.
+- Add a "Publishing to understand-quickly" paragraph to the codebase-digest README.
+
+## Why a sidecar
+
+The registry indexes a small JSON manifest (the `bundle@1` shape), not the digest body. Two files keeps the existing digest output unchanged, lets the registry fetch quickly + validate, and decouples body churn from manifest churn. A reference fixture lives at [`schemas/__fixtures__/bundle/real-sample.json`](https://github.com/looptech-ai/understand-quickly/blob/main/schemas/__fixtures__/bundle/real-sample.json).
+
+## No-op default
+
+`--publish` is opt-in. Existing users see no change. With `--publish` but no `UNDERSTAND_QUICKLY_TOKEN`, codebase-digest writes the sidecar and prints one informational line — no network call, no exit-1.
+
+## Token setup
+
+Fine-grained GitHub PAT, single permission:
+
+- **Repository access:** `looptech-ai/understand-quickly` only.
+- **Permissions:** `Repository dispatches: write`. Nothing else.
+
+Drop-in workflow at [`docs/integrations/sample-publish-workflow.yml`](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml).
+
+## Test plan
+
+- [ ] Default invocation produces the same digest as before — no sidecar.
+- [ ] `codebase-digest --publish` writes both the digest AND `.codebase-digest/digest.bundle.json`.
+- [ ] The sidecar validates against `schemas/bundle@1.json`.
+- [ ] With `UNDERSTAND_QUICKLY_TOKEN` set and the repo registered, `--publish` fires the dispatch.
+- [ ] With the token set but the repo unregistered, prints the registration hint; exit code 0.
+- [ ] `manifest.commit` is the 40-hex `git rev-parse HEAD`; `manifest.tool == "codebase-digest"`; `manifest.format == "plaintext"`; analyzer metrics populated.
+
+## Notes for the maintainer
+
+- This is opt-in for early adopters; nothing in codebase-digest's existing surface needs to break.
+- Once codebase-digest has shipped this and a few users land in the registry, we can add `kamilstanuch/codebase-digest` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge.
+
+## Links
+
+- Registry: <https://github.com/looptech-ai/understand-quickly>
+- Integration protocol: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md>
+- `bundle@1` schema: <https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json>
+- Sample workflow: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml>
+- Verified publishers: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md>

--- a/docs/integrations/codebase-digest-pr.md
+++ b/docs/integrations/codebase-digest-pr.md
@@ -60,6 +60,8 @@ Drop-in workflow at [`docs/integrations/sample-publish-workflow.yml`](https://gi
 - This is opt-in for early adopters; nothing in codebase-digest's existing surface needs to break.
 - Once codebase-digest has shipped this and a few users land in the registry, we can add `kamilstanuch/codebase-digest` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge.
 
+- **What this means licensing-wise for your users.** Submitting via `--publish` is governed by the [Understand-Quickly Data License 1.0](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) — see [protocol §10](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#10-licensing-of-submitted-data). It is opt-in, gated on the user setting `UNDERSTAND_QUICKLY_TOKEN`; consider mirroring this paragraph in your own `--publish` documentation so users know what they are consenting to.
+
 ## Links
 
 - Registry: <https://github.com/looptech-ai/understand-quickly>

--- a/docs/integrations/codebase-memory-mcp-pr.md
+++ b/docs/integrations/codebase-memory-mcp-pr.md
@@ -62,6 +62,8 @@ A drop-in workflow snippet lives at [`docs/integrations/sample-publish-workflow.
 - This is opt-in for early adopters; nothing in codebase-memory-mcp's existing API surface needs to break.
 - Once the integration ships and a few users land in the registry, we can add `DeusData/codebase-memory-mcp` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge of registry updates.
 
+- **What this means licensing-wise for your users.** Submitting via `--publish` is governed by the [Understand-Quickly Data License 1.0](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) — see [protocol §10](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#10-licensing-of-submitted-data). It is opt-in, gated on the user setting `UNDERSTAND_QUICKLY_TOKEN`; consider mirroring this paragraph in your own `--publish` documentation so users know what they are consenting to.
+
 ## Links
 
 - Registry: <https://github.com/looptech-ai/understand-quickly>

--- a/docs/integrations/codebase-memory-mcp-pr.md
+++ b/docs/integrations/codebase-memory-mcp-pr.md
@@ -1,0 +1,71 @@
+# PR draft — codebase-memory-mcp → understand-quickly
+
+Target repo: [`DeusData/codebase-memory-mcp`](https://github.com/DeusData/codebase-memory-mcp)
+
+Paste the body below into the PR description on that repo. The author should confirm the exact CLI / server command surface (whether the persistent KG is built via a separate `codebase-memory build` step or implicitly on first connect), the conventional graph file path (this draft assumes `.codebase-memory/graph.json`), and which existing schema is the closest fit. The rest is repo-agnostic.
+
+---
+
+## Title
+
+`Add --publish flag for understand-quickly registry integration`
+
+## Why
+
+[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public registry of code-knowledge graphs that ships its own MCP server and a stable `registry.json` API. codebase-memory-mcp is itself an MCP server backed by a persistent code-knowledge graph — the registry is the natural place for those graphs to be discovered by *other* agents (Claude, Codex, Cursor) without each user pointing at a private endpoint.
+
+Wiring a `--publish` flag (or a one-off `codebase-memory publish` subcommand) means any user who builds a codebase-memory graph can land in the registry with a single token, and any MCP-aware agent can resolve their repo to a graph URL via the registry's `find_graph_for_repo` tool.
+
+- **Discoverability.** Every published codebase-memory graph appears at <https://looptech-ai.github.io/understand-quickly/>.
+- **No infrastructure on our side.** Graphs stay in the user's repo (`.codebase-memory/graph.json`); the registry only stores pointers and fetches from `raw.githubusercontent.com`.
+- **Cross-agent reuse.** A graph built by codebase-memory-mcp becomes consumable by any agent that speaks the registry's MCP API — no shared server required.
+
+## What changes
+
+- Add a `--publish` flag (or `codebase-memory publish` subcommand) that flushes the in-memory KG to a stable JSON file at `.codebase-memory/graph.json` and, if `$UNDERSTAND_QUICKLY_TOKEN` is set, fires a `repository_dispatch` event at `looptech-ai/understand-quickly`.
+- Embed `metadata.commit = $(git rev-parse HEAD)`, `metadata.tool == "codebase-memory-mcp"`, `metadata.tool_version`, and `metadata.generated_at` in the emitted graph.
+- If the user's repo isn't yet in the registry, print a friendly one-liner pointing at `npx @understand-quickly/cli add` or the wizard and exit cleanly.
+- Add a "Publishing to understand-quickly" paragraph to the README near the existing MCP server docs.
+
+## Schema fit
+
+codebase-memory-mcp emits a node/edge graph over a codebase. Two paths:
+
+1. **Reuse `gitnexus@1`** if existing field names align (`nodes[].id`, `nodes[].kind`, `edges[].source`, `edges[].target`). Fastest path — register today, no schema PR.
+2. **Land a `codebase-memory@1` schema** if the persisted shape carries memory-specific fields (recency, access counts, embedding refs). Format-authoring path: [`docs/integrations/protocol.md §7`](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#7-format-authoring) — one PR adding the schema + fixtures.
+
+If you'd like, the registry maintainers can take the schema PR — drop a sample graph into a registry issue and we'll wire it up.
+
+## No-op default
+
+`--publish` is opt-in. Existing users see no change. With `--publish` but no `UNDERSTAND_QUICKLY_TOKEN`, the tool writes the file as usual and prints one informational line — no network call, no exit-1.
+
+## Token setup
+
+The user adds a fine-grained GitHub PAT to their environment (or repo secrets, when run from CI):
+
+- **Repository access:** `looptech-ai/understand-quickly` only.
+- **Permissions:** `Repository dispatches: write`. Nothing else.
+
+A drop-in workflow snippet lives at [`docs/integrations/sample-publish-workflow.yml`](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml).
+
+## Test plan
+
+- [ ] Default invocation behavior unchanged (no graph file written unless explicitly requested).
+- [ ] `... --publish` with `UNDERSTAND_QUICKLY_TOKEN` unset writes `.codebase-memory/graph.json` and prints an informational message; exit code 0.
+- [ ] `... --publish` with the token set and the repo registered fires the dispatch and the registry's `sync.yml` runs within roughly a minute.
+- [ ] `... --publish` with the token set but the repo unregistered prints `register it once with: npx @understand-quickly/cli add`; exit code 0.
+- [ ] Emitted graph contains `metadata.tool == "codebase-memory-mcp"`, `metadata.tool_version`, `metadata.generated_at`, and `metadata.commit` (40-hex sha).
+
+## Notes for the maintainer
+
+- This is opt-in for early adopters; nothing in codebase-memory-mcp's existing API surface needs to break.
+- Once the integration ships and a few users land in the registry, we can add `DeusData/codebase-memory-mcp` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge of registry updates.
+
+## Links
+
+- Registry: <https://github.com/looptech-ai/understand-quickly>
+- Integration protocol: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md>
+- `gitnexus@1` schema (closest fit): <https://github.com/looptech-ai/understand-quickly/blob/main/schemas/gitnexus@1.json>
+- Sample workflow: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml>
+- Verified publishers: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md>

--- a/docs/integrations/deepwiki-open-pr.md
+++ b/docs/integrations/deepwiki-open-pr.md
@@ -61,6 +61,8 @@ A drop-in workflow snippet lives at [`docs/integrations/sample-publish-workflow.
 - This is opt-in for early adopters; nothing in deepwiki-open's existing API surface needs to break.
 - Once the integration ships and a few users land in the registry, we can add `AsyncFuncAI/deepwiki-open` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge of registry updates.
 
+- **What this means licensing-wise for your users.** Submitting via `--publish` is governed by the [Understand-Quickly Data License 1.0](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) — see [protocol §10](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#10-licensing-of-submitted-data). It is opt-in, gated on the user setting `UNDERSTAND_QUICKLY_TOKEN`; consider mirroring this paragraph in your own `--publish` documentation so users know what they are consenting to.
+
 ## Links
 
 - Registry: <https://github.com/looptech-ai/understand-quickly>

--- a/docs/integrations/deepwiki-open-pr.md
+++ b/docs/integrations/deepwiki-open-pr.md
@@ -1,0 +1,71 @@
+# PR draft — deepwiki-open → understand-quickly
+
+Target repo: [`AsyncFuncAI/deepwiki-open`](https://github.com/AsyncFuncAI/deepwiki-open)
+
+Paste the body below into the PR description on that repo. The author should confirm the exact CLI command (`deepwiki build`, `deepwiki gen`, etc.), the conventional output path (this draft assumes `.deepwiki/wiki.json`), and pick the schema target (`generic@1` for a fast first integration, or land a new `wiki@1` for richer wiki-specific structure). The rest of the wording is repo-agnostic.
+
+---
+
+## Title
+
+`Add --publish flag for understand-quickly registry integration`
+
+## Why
+
+[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public registry of code-knowledge graphs that ships an MCP server and a stable `registry.json` API. deepwiki-open is the open clone of DeepWiki — a wiki-from-code generator. Wiring a `--publish` flag means any user who generates a deepwiki for their repo can land in the registry with one flag, and AI agents (Claude, Codex, Cursor via MCP) can discover and consume their wiki immediately.
+
+- **Discoverability.** Every published deepwiki appears at <https://looptech-ai.github.io/understand-quickly/>.
+- **No infrastructure on our side.** Wiki output stays in the user's repo (`.deepwiki/wiki.json`); the registry only stores pointers and fetches from `raw.githubusercontent.com`.
+- **Agent-consumable.** Schema validation, drift detection (when `metadata.commit` is set), and a turnkey MCP server.
+
+## What changes
+
+- Add a `--publish` flag (or equivalent — `--register`, `--publish-to-uq`) to the deepwiki-open generator command. If a programmatic API is exposed, accept the same option there.
+- After the existing wiki generation step, when `--publish` is set: fire a `repository_dispatch` event at `looptech-ai/understand-quickly` using a token from `$UNDERSTAND_QUICKLY_TOKEN`.
+- Embed `metadata.commit = $(git rev-parse HEAD)`, `metadata.tool == "deepwiki-open"`, `metadata.tool_version`, and `metadata.generated_at` in the emitted JSON.
+- If the user's repo isn't yet in the registry, print a friendly one-liner pointing at `npx @understand-quickly/cli add` or the wizard and exit cleanly — don't fail the parent run.
+- Add a "Publishing to understand-quickly" paragraph to the README.
+
+## Schema fit
+
+deepwiki-open emits a structured wiki (sections, articles, links). Two paths:
+
+1. **Reuse `generic@1`** for a fast first integration — the fallback schema only requires `nodes` and `edges` arrays, so a flat node-per-article shape lands today with no schema PR. Good enough for "the registry knows this wiki exists" UX.
+2. **Land a `wiki@1` schema** that captures wiki-specific structure (article headings, cross-links, citations). The format-authoring path is documented in [`docs/integrations/protocol.md §7`](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#7-format-authoring) — one PR adding `schemas/wiki@1.json` + fixtures (`ok.json`, `bad.json`, `real-sample.json`).
+
+Recommended sequence: ship the integration first against `generic@1` to validate adoption; co-author `wiki@1` once a couple of users land in the registry.
+
+## No-op default
+
+`--publish` is opt-in. Existing users see no change. With `--publish` but no `UNDERSTAND_QUICKLY_TOKEN`, the tool writes the wiki file as usual and prints one informational line — no network call, no exit-1.
+
+## Token setup
+
+The user adds a fine-grained GitHub PAT to their environment (or repo secrets, when run from CI):
+
+- **Repository access:** `looptech-ai/understand-quickly` only.
+- **Permissions:** `Repository dispatches: write`. Nothing else.
+
+A drop-in workflow snippet lives at [`docs/integrations/sample-publish-workflow.yml`](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml).
+
+## Test plan
+
+- [ ] Default invocation writes `.deepwiki/wiki.json` exactly as before.
+- [ ] `... --publish` with `UNDERSTAND_QUICKLY_TOKEN` unset writes the file and prints an informational message; exit code 0.
+- [ ] `... --publish` with the token set and the repo registered fires the dispatch and the registry's `sync.yml` runs within roughly a minute.
+- [ ] `... --publish` with the token set but the repo unregistered prints `register it once with: npx @understand-quickly/cli add`; exit code 0.
+- [ ] Emitted file contains `metadata.tool == "deepwiki-open"`, `metadata.tool_version`, `metadata.generated_at`, and `metadata.commit` (40-hex sha).
+
+## Notes for the maintainer
+
+- This is opt-in for early adopters; nothing in deepwiki-open's existing API surface needs to break.
+- Once the integration ships and a few users land in the registry, we can add `AsyncFuncAI/deepwiki-open` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge of registry updates.
+
+## Links
+
+- Registry: <https://github.com/looptech-ai/understand-quickly>
+- Integration protocol: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md>
+- `generic@1` schema (fast-path): <https://github.com/looptech-ai/understand-quickly/blob/main/schemas/generic@1.json>
+- Format authoring (for `wiki@1`): <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#7-format-authoring>
+- Sample workflow: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml>
+- Verified publishers: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md>

--- a/docs/integrations/gitingest-pr.md
+++ b/docs/integrations/gitingest-pr.md
@@ -1,0 +1,75 @@
+# PR draft — gitingest → understand-quickly
+
+Target repo: [`cyclotruc/gitingest`](https://github.com/cyclotruc/gitingest)
+
+Paste the body below into the PR description on that repo. The author should confirm the exact CLI surface (`gitingest`, `python -m gitingest`, the web UI export path) and the conventional output filename (this draft assumes `digest.md` for the body and a sidecar `.gitingest/digest.bundle.json` for the registry pointer). The rest is repo-agnostic.
+
+---
+
+## Title
+
+`Add --publish flag for understand-quickly registry integration`
+
+## Why
+
+[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public registry of code-knowledge **and** code-context artifacts that ships an MCP server and a stable `registry.json` API. gitingest is one of the most-used "pack a repo into context" tools; the registry's [`bundle@1`](https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json) format was designed exactly to index gitingest-style outputs.
+
+Wiring a `--publish` flag means any user who runs gitingest can land in the registry with one flag, and AI agents (Claude, Codex, Cursor via MCP) can resolve a repo URL to its packed-context digest via the registry's `find_graph_for_repo` tool.
+
+- **Discoverability.** Every published gitingest digest appears at <https://looptech-ai.github.io/understand-quickly/>.
+- **No infrastructure on our side.** The markdown digest stays in the user's repo; the registry only stores a small JSON pointer (`bundle@1` manifest) plus the `content_url`.
+- **Agent-consumable.** MCP clients can fetch the digest through the registry without each user maintaining a private mapping.
+
+## What changes
+
+- Add a `--publish` flag (or equivalent — `--register`, `--publish-to-uq`) to the gitingest CLI / web export.
+- After the existing digest step, when `--publish` is set:
+  1. Write a small JSON sidecar at `.gitingest/digest.bundle.json` that conforms to the registry's [`bundle@1`](https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json) schema. The sidecar carries `manifest.tool = "gitingest"`, `tool_version`, `generated_at`, `commit`, `file_count`, `byte_count`, `token_estimate`, `format = "markdown"`, and `content_url` pointing at the existing markdown digest in the same repo (e.g. `https://raw.githubusercontent.com/$OWNER/$REPO/main/digest.md`).
+  2. If `$UNDERSTAND_QUICKLY_TOKEN` is set, fire a `repository_dispatch` event at `looptech-ai/understand-quickly`. Otherwise, write the sidecar locally and exit cleanly.
+- If the user's repo isn't yet in the registry, print a friendly one-liner pointing at `npx @understand-quickly/cli add` or the wizard and exit cleanly — don't fail the parent run.
+- Add a "Publishing to understand-quickly" paragraph to the gitingest README.
+
+## Why a sidecar
+
+The registry indexes a small JSON manifest (the `bundle@1` shape), not the markdown digest itself. Keeping these as two files means:
+
+- Existing gitingest users see no change to their digest output.
+- The registry fetches a small sidecar quickly, validates schema, and then optionally streams the larger body via `content_url`.
+- Future bundle schema revisions don't require regenerating the digest.
+
+A reference fixture lives at [`schemas/__fixtures__/bundle/real-sample.json`](https://github.com/looptech-ai/understand-quickly/blob/main/schemas/__fixtures__/bundle/real-sample.json).
+
+## No-op default
+
+`--publish` is opt-in. Existing users see no change. With `--publish` but no `UNDERSTAND_QUICKLY_TOKEN`, gitingest writes the sidecar and prints one informational line — no network call, no exit-1.
+
+## Token setup
+
+Fine-grained GitHub PAT, single permission:
+
+- **Repository access:** `looptech-ai/understand-quickly` only.
+- **Permissions:** `Repository dispatches: write`. Nothing else.
+
+Drop-in workflow at [`docs/integrations/sample-publish-workflow.yml`](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml).
+
+## Test plan
+
+- [ ] Default invocation produces the same digest as before — no sidecar.
+- [ ] `gitingest --publish` writes both the digest AND `.gitingest/digest.bundle.json`.
+- [ ] The sidecar validates against `schemas/bundle@1.json`.
+- [ ] With `UNDERSTAND_QUICKLY_TOKEN` set and the repo registered, `--publish` fires the dispatch.
+- [ ] With the token set but the repo unregistered, prints the registration hint; exit code 0.
+- [ ] `manifest.commit` is the 40-hex `git rev-parse HEAD`; `manifest.tool == "gitingest"`; `manifest.format == "markdown"`.
+
+## Notes for the maintainer
+
+- This is opt-in for early adopters; nothing in gitingest's existing surface needs to break.
+- Once gitingest has shipped this and a few users land in the registry, we can add `cyclotruc/gitingest` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge of registry updates from the integration.
+
+## Links
+
+- Registry: <https://github.com/looptech-ai/understand-quickly>
+- Integration protocol: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md>
+- `bundle@1` schema: <https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json>
+- Sample workflow: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml>
+- Verified publishers: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md>

--- a/docs/integrations/gitingest-pr.md
+++ b/docs/integrations/gitingest-pr.md
@@ -66,6 +66,8 @@ Drop-in workflow at [`docs/integrations/sample-publish-workflow.yml`](https://gi
 - This is opt-in for early adopters; nothing in gitingest's existing surface needs to break.
 - Once gitingest has shipped this and a few users land in the registry, we can add `cyclotruc/gitingest` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge of registry updates from the integration.
 
+- **What this means licensing-wise for your users.** Submitting via `--publish` is governed by the [Understand-Quickly Data License 1.0](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) — see [protocol §10](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#10-licensing-of-submitted-data). It is opt-in, gated on the user setting `UNDERSTAND_QUICKLY_TOKEN`; consider mirroring this paragraph in your own `--publish` documentation so users know what they are consenting to.
+
 ## Links
 
 - Registry: <https://github.com/looptech-ai/understand-quickly>

--- a/docs/integrations/gitnexus-pr-1425-handoff.md
+++ b/docs/integrations/gitnexus-pr-1425-handoff.md
@@ -1,0 +1,269 @@
+# Handoff prompt for a local Claude session — execute GitNexus PR #1425 cleanup
+
+> **Read this file once, then start working. Everything you need is here or
+> linked from here. Do not load my prior session's transcript.**
+>
+> You are taking over a partially-completed code review response from a
+> sandboxed Claude session whose GitHub MCP allowlist was scoped to
+> `looptech-ai/understand-quickly`. Your job is to land the parts that
+> session could not: applying patches to `abhigyanpatwari/GitNexus`,
+> posting reply comments on PR #1425, and confirming CI.
+
+---
+
+## Constraints you must honor
+
+1. **`abhigyanpatwari/GitNexus` is licensed PolyForm Noncommercial 1.0.0.**
+   Before you push *any* code-bearing commit to that repo, ask the human
+   user whether they have signed a CLA (or equivalent) with the upstream
+   maintainer. If they haven't, **stop** and surface that to the user — do
+   not push. Doc updates and comment posts are fine to proceed with; only
+   code patches are gated on the licensing question.
+2. **Use the user's authenticated GitHub identity** (`gh` CLI / the MCP
+   server you have access to). Do not impersonate, do not use a token from
+   a different account.
+3. **Confirm before any destructive action**: force-pushing to a branch
+   that exists upstream, closing the PR, deleting the branch. Non-
+   destructive actions (paste comments, push new commits to the PR head
+   branch the user controls) proceed without confirmation.
+4. **Sign every commit** with `Signed-off-by: <user>` per DCO.
+
+---
+
+## What's already done (do not repeat)
+
+- Comprehensive review responses + drop-in patches drafted in:
+  `looptech-ai/understand-quickly:docs/integrations/gitnexus-pr-1425-responses.md`
+  (commit `f09f2b7` on branch `claude/check-session-status-NWWiy`).
+- Mobile-friendly playbook at
+  `looptech-ai/understand-quickly:docs/integrations/gitnexus-pr-1425-quick-paste.md`
+  (commit `3395653`).
+- This handoff file is on the same branch.
+
+Do not re-derive the patches. Read those two files; they are the spec.
+
+---
+
+## Inputs
+
+- **PR:** <https://github.com/abhigyanpatwari/GitNexus/pull/1425>
+- **PR head SHA at time of review:** `3ea22fd`
+- **PR head branch (owned by `looptech-ai` or `amacsmith`):**
+  whatever the PR's `head.ref` resolves to — fetch via `gh pr view 1425 --repo abhigyanpatwari/GitNexus --json headRefName`.
+- **Full review with verbatim findings:** the senior code review pasted in
+  the user's prior message. The summary lives in `gitnexus-pr-1425-responses.md`.
+- **Open BLOCKERs (3) + HIGHs (1) + MEDIUMs (2) + LOWs (3)** —
+  enumerated below in execution order.
+
+---
+
+## Execution plan — do these in order, stop if any step fails
+
+### Step 0 — Sanity checks
+
+```bash
+# Repo + PR exist and are open
+gh pr view 1425 --repo abhigyanpatwari/GitNexus --json state,headRefName,headRepository
+
+# CI failures: confirm whether they reproduce on `main`
+gh repo clone abhigyanpatwari/GitNexus /tmp/gitnexus
+cd /tmp/gitnexus
+git checkout main
+npm install
+npm test --workspace=gitnexus -- test/integration/cli-e2e.test.ts -t '(#324)' || true
+```
+
+If the 5 `(#324)` tests fail on `main` too, they're pre-existing — note
+this in the CI thread reply (Step 4) and continue. If `main` is green,
+bisect into the publish branch first; the patches below should not have
+introduced those failures, but verify before pushing.
+
+### Step 1 — Confirm licensing path
+
+Ask the human user:
+
+> "PR #1425 lands code in `abhigyanpatwari/GitNexus`, which is PolyForm
+> Noncommercial 1.0.0. Have you signed a CLA or otherwise resolved the
+> contributor-licensing question with the upstream maintainer? If not, I
+> will pause before pushing code; comment-only replies will still proceed."
+
+If the answer is "no" or "unclear": continue with comment posts (Step 4)
+but **skip Steps 2 + 3** (code pushes). Surface the gate clearly when
+done.
+
+### Step 2 — Apply patches to a fresh branch off the PR head
+
+```bash
+cd /tmp/gitnexus
+gh pr checkout 1425
+git checkout -b claude/uq-publish-fixes
+```
+
+Apply the seven patch sections from `gitnexus-pr-1425-responses.md` in
+this exact order. Each section is single-file-scoped and does not
+conflict with the others. After each, run the matching local test to
+verify.
+
+| # | Patch source in responses doc | Files touched | Verify |
+| --- | --- | --- | --- |
+| 1 | "BLOCKER 1 — CodeQL ReDoS" → Patch | `gitnexus-shared/src/integrations/understand-quickly.ts`; new `__tests__` file | `npm test --workspace=gitnexus-shared -- understand-quickly` |
+| 2 | "BLOCKER 2 — token gate" → Patch | `gitnexus/src/cli/publish.ts` (move token check to step 0) | `npm test --workspace=gitnexus -- test/unit/publish.test.ts` |
+| 3 | "BLOCKER 3 — 401 handling" → Patch | `gitnexus/src/cli/publish.ts` (response branches) | same |
+| 4 | "HIGH 4 — fetch timeout" → Patch | `gitnexus/src/cli/publish.ts` (AbortSignal + UA) | same |
+| 5 | "MEDIUM 5 — test coverage" → 7 new tests | `gitnexus/test/unit/publish.test.ts` | `npm test --workspace=gitnexus` (expect 8197 + 7 = 8204 pass on the publish branch) |
+| 6 | "LOW 8 — owner-repo regex" → Patch | `gitnexus-shared/src/integrations/understand-quickly.ts` (`OWNER_REPO_RE`) | `npm test --workspace=gitnexus-shared` |
+| 7 | "LOW 9 — non-GitHub host" → Patch | same file (`parseOwnerRepoFromRemote` host guard) | same |
+
+The `getCurrentCommit` move (LOW 7) is folded into BLOCKER 3's patch.
+
+After all seven:
+
+```bash
+npm run typecheck
+npm run lint
+npm test
+```
+
+Expect the 5 `(#324)` tests to still fail (out of scope) but everything
+else green, including 7 new publish.test.ts cases.
+
+### Step 3 — Push the patches
+
+```bash
+git add -A
+git commit -s -m "fix(uq-publish): address review blockers + high-severity items
+
+Addresses CodeQL polynomial-regex (HIGH), token-gate ordering, distinct
+401/403/404/422 response branches, fetch timeout, expanded test coverage,
+tightened owner/repo validation, and non-GitHub remote rejection.
+
+See response thread on PR #1425 for the per-finding rationale."
+git push origin HEAD:<original-pr-head-branch>
+```
+
+Replace `<original-pr-head-branch>` with the value resolved in Step 0.
+This pushes onto the PR head, so #1425 picks up the new commits
+automatically. Do **not** force-push. If the push is rejected because
+the head ref isn't yours to write to, fall back to opening a chained PR
+against #1425's head branch and surface that to the user.
+
+### Step 4 — Post the reply comments
+
+Use the verbatim text blocks from
+[`gitnexus-pr-1425-quick-paste.md`](./gitnexus-pr-1425-quick-paste.md),
+**not** the longer responses doc. The quick-paste blocks are tuned for
+direct posting; the responses doc is for engineers reading the rationale.
+
+For each block, replace literal `<sha>` with the commit SHA you just
+pushed in Step 3. If you skipped Step 3 (licensing gate), leave `<sha>`
+literal and add a note "patches drafted but not pushed pending CLA
+resolution".
+
+Posting commands:
+
+```bash
+# Top-level summary (§0 of quick-paste doc)
+gh pr comment 1425 --repo abhigyanpatwari/GitNexus --body-file /tmp/uq-§0.md
+
+# Inline review reply on the CodeQL alert thread (§1)
+# Find the review-thread id:
+gh api repos/abhigyanpatwari/GitNexus/pulls/1425/comments --jq '.[] | {id, path, line, user: .user.login}'
+# then:
+gh api -X POST repos/abhigyanpatwari/GitNexus/pulls/1425/comments/<thread-id>/replies \
+  --field body=@/tmp/uq-§1.md
+
+# Repeat for §2, §3, §4, §5a/5b/5c (skip any thread that doesn't exist
+# upstream — Copilot may not have left a comment on every file).
+```
+
+If `gh api .../replies` is unavailable on the user's `gh` version, fall
+back to creating a new review with `inline` comments matched to each
+existing thread's `path` and `line`.
+
+### Step 5 — Confirm CodeQL clears
+
+```bash
+# Wait for the next CodeQL run (5-10 min after push)
+sleep 300
+gh pr checks 1425 --repo abhigyanpatwari/GitNexus
+```
+
+The previously-flagged alert at
+`gitnexus-shared/src/integrations/understand-quickly.ts:89` should clear.
+If it doesn't, read the new alert and propose a follow-up patch before
+exiting.
+
+### Step 6 — Final report to the user
+
+End your run by posting in the user's chat:
+
+- Whether Step 3 (code push) ran or was gated by licensing.
+- The new commit SHA on the PR head, if pushed.
+- The list of comment threads where you posted replies (with permalinks).
+- Whether CodeQL cleared.
+- Whether the 5 `(#324)` failures are pre-existing on `main`.
+- Any unresolved questions for the user (CLA path, follow-up bisect, etc.).
+
+Do **not** mark anything "done" until all of the above has been reported
+back, even if individual gh commands succeeded.
+
+---
+
+## What you must NOT do
+
+- Do not modify `looptech-ai/understand-quickly` from this session. The
+  prior session owns that branch (`claude/check-session-status-NWWiy`).
+  If you discover something that needs changing on the registry side
+  (e.g., the response doc has a typo), surface it to the user and let
+  the next registry-scoped session pick it up.
+- Do not merge PR #1425. The decision to merge is the upstream
+  maintainer's, after reviewing the responses + the new commits.
+- Do not file new issues on `abhigyanpatwari/GitNexus` without user
+  approval.
+- Do not amend or rebase the existing PR commits. New commits on top
+  only.
+
+---
+
+## Glossary
+
+- **Registry:** the `looptech-ai/understand-quickly` repo. A directory of
+  code-knowledge graphs and repo-context bundles for AI agents to fetch
+  by URL. Apache 2.0 + a viral data-use license.
+- **`bundle@1`:** the registry's format for repo-context packers
+  (Repomix, gitingest, codebase-digest). Distinct from `gitnexus@1`.
+- **GitNexus's `publish` command:** opt-in `gitnexus publish` subcommand
+  that fires a `repository_dispatch` event at the registry. Does **not**
+  upload graph content; the registry pulls from a `raw.githubusercontent.com`
+  URL the user previously registered.
+- **`UNDERSTAND_QUICKLY_TOKEN`:** fine-grained PAT with
+  `Repository dispatches: write` scope on `looptech-ai/understand-quickly`
+  only. Required for the dispatch; absent → publish is a no-op (per the
+  contract this PR is fixing).
+
+---
+
+## Stop-conditions
+
+If any of these are true, stop and ask the user:
+
+1. The PR head branch is not in a repo you can push to.
+2. CLA / licensing has not been resolved (Step 1).
+3. A test other than the 5 known `(#324)` cases fails after Step 2.
+4. CodeQL flags a new finding after Step 3.
+5. `gh api` fails with 401/403 (token issue).
+6. The PR has been closed, merged, or moved to a different branch since
+   the head SHA `3ea22fd`.
+
+In any stop case, summarize the state of the world and the proposed next
+action, then exit cleanly. Do not improvise.
+
+---
+
+## Why this prompt is written this way
+
+The original session that drafted the responses had no write access to
+`abhigyanpatwari/GitNexus`. Rather than load that session's transcript
+(which is large and partially out of scope), this prompt is the minimal
+self-contained work order. Read it, follow it, ask when blocked, report
+back.

--- a/docs/integrations/gitnexus-pr-1425-quick-paste.md
+++ b/docs/integrations/gitnexus-pr-1425-quick-paste.md
@@ -1,0 +1,262 @@
+# Quick-paste playbook — GitNexus #1425 (phone-friendly)
+
+> Open this file on github.com mobile or the GitHub app. Each section below
+> is a self-contained block — tap-and-hold inside the fenced text to select
+> all + copy. Then tap the URL above the block to jump to the right thread,
+> tap **Reply** / **Comment**, paste, submit.
+>
+> Order: blockers first (must clear before merge), then the rest. The
+> patches are at the bottom — those you'll have to apply from a desktop or
+> Codespace; pasting them into the phone won't help.
+>
+> Companion doc with full reasoning + drop-in code:
+> [`gitnexus-pr-1425-responses.md`](./gitnexus-pr-1425-responses.md).
+
+---
+
+## 0 · Top-level PR comment (paste once at the bottom of the conversation tab)
+
+**Tap to open:** <https://github.com/abhigyanpatwari/GitNexus/pull/1425>
+
+Scroll to the comment box at the bottom of the **Conversation** tab.
+
+```text
+Thanks for the thorough review. Working through it now — three blockers
+queued for the next push:
+
+1. **CodeQL ReDoS** on `parseOwnerRepoFromRemote`. Replacing the chained
+   `.replace(/\.git\/*$/i, '').replace(/\/+$/, '')` with a bounded linear
+   `stripGitSuffix` helper. Adding a 10,000-slash regression test to pin
+   the linear bound.
+2. **Token gate ordering.** Moving the `UNDERSTAND_QUICKLY_TOKEN` check to
+   step 0 of `publishCommand` so the documented "exit 0 without token"
+   contract is true even when no GitNexus index exists yet.
+3. **Distinct 401 handling.** Splitting the response branches into
+   204 / 401 / 403 / 404 / 422 / 5xx, each with a targeted remediation
+   message (regenerate PAT vs. add scope vs. fix repo access vs. CLI bug).
+
+Plus the high/medium items: 15 s `AbortSignal.timeout` on the dispatch
+fetch, 7 new fetch-spy tests covering every documented exit path
+(including a token-leak guard), and corrections to the README + this PR
+description on what a 204 actually confirms (acceptance, not registry
+processing).
+
+CI: the 5 failing `cli-e2e.test.ts` cases are all in `(#324)` describe
+blocks exercising `cypher` / `query` / `impact` — none of which this PR
+touches. Could you confirm whether those same 5 fail on `main`? If so,
+they're pre-existing; if not, I'll bisect.
+
+On licensing: happy to sign a CLA, add a contributor agreement, or
+re-license the contribution under PolyForm Noncommercial — your call on
+what's most useful. Will hold the merge until that's settled.
+```
+
+---
+
+## 1 · CodeQL alert (BLOCKER)
+
+**Tap to open:** <https://github.com/abhigyanpatwari/GitNexus/pull/1425/files#diff-understand-quickly-ts>
+
+Scroll to the CodeQL inline alert on `gitnexus-shared/src/integrations/understand-quickly.ts`. Tap **Reply**.
+
+```text
+Confirmed. Replacing the two chained `.replace` calls with a bounded
+linear `stripGitSuffix` helper that visits each character at most twice.
+Adding a regression test with a 10,000-slash adversarial input to pin the
+linear time bound. Also backporting the same helper to the duplicated
+strip in `gitnexus/src/storage/git.ts:271` (`parseRepoNameFromUrl`) — same
+pattern, not currently CodeQL-flagged because it consumes a local-
+subprocess string, but worth aligning so the two strip implementations
+don't drift. Pushed in <sha>.
+```
+
+---
+
+## 2 · `publish.ts` index-precondition thread (BLOCKER 2)
+
+**Tap to open:** <https://github.com/abhigyanpatwari/GitNexus/pull/1425/files#diff-publish-ts-L70>
+
+The thread on lines ~70-80 of `gitnexus/src/cli/publish.ts`. Tap **Reply**.
+
+```text
+Right — the README, --help text, and the PR body all promise "exit 0
+without UNDERSTAND_QUICKLY_TOKEN" but the index check fires before the
+token gate, so missing-index + no-token currently exits 1. Moving the
+token gate to step 0 of `publishCommand`, ahead of repo-root resolution
+and `hasIndex`. Without a token, print one informational line and
+`return`. Makes the contract literally true and lets users smoke-test
+`gitnexus publish` before they've run `analyze`. Pushed in <sha>.
+```
+
+---
+
+## 3 · `publish.ts` fetch headers (HIGH)
+
+**Tap to open:** <https://github.com/abhigyanpatwari/GitNexus/pull/1425/files#diff-publish-ts-L114>
+
+Thread on lines ~114-123. Tap **Reply**.
+
+```text
+Three replies, since the comment likely covers a couple of these:
+
+- **`User-Agent`**: agreed, GitHub recommends one even on PAT-auth
+  requests. Adding `gitnexus-cli`. Pushed in <sha>.
+- **`AbortController` timeout**: agreed. A hung dispatch would otherwise
+  stall a CI publish step until the OS TCP timeout (~2 min) with no
+  signal. Wiring `AbortSignal.timeout(15_000)` matching the pattern
+  already in `src/core/embeddings/http-client.ts`, with a targeted
+  `AbortError` branch so the user sees "dispatch timed out" rather than
+  a raw stack. Pushed in <sha>.
+- **Retry on 5xx**: declining. `repository_dispatch` is a single
+  idempotent ping; the registry's nightly sync covers any one missed
+  dispatch. Adding retry would also need correct 429 rate-limit handling
+  and is overkill for this failure mode. Open to revisiting if real
+  users hit it.
+
+Token leakage: confirmed safe — token is only in `headers`, no log path
+prints `headers`, and `cliError` calls log `id` and `status` only.
+```
+
+---
+
+## 4 · `publish.ts` response handling (BLOCKER 3)
+
+**Tap to open:** <https://github.com/abhigyanpatwari/GitNexus/pull/1425/files#diff-publish-ts-L131>
+
+Thread on lines ~131-134. Tap **Reply**.
+
+```text
+Right — the comment promises distinct handling of 401 but the code only
+branches on 204 and 404. Adding explicit branches for 401 (PAT invalid
+or expired → regenerate hint), 403 (PAT lacks "Repository dispatches:
+write" scope → fix-scope hint), 404 (PAT can't reach the registry repo
+→ verify-access hint), and 422 (malformed event payload → "this is a
+CLI bug, please report"). Generic 5xx falls through unchanged with the
+body dump.
+
+Also: the success message on 204 now points users at the registry's
+sync.yml workflow logs as the source of truth for whether the registry
+*processed* the dispatch — the CLI cannot know synchronously whether the
+id was registered. Pushed in <sha>.
+```
+
+---
+
+## 5 · README / cli/index.ts / publish.test.ts threads
+
+If Copilot left specific threads on each of these, paste the matching
+block. If you can't tell which file a thread belongs to, paste the
+generic test-coverage block at the bottom and reference it from the
+top-level summary.
+
+### 5a · README.md thread
+
+**Tap to open:** <https://github.com/abhigyanpatwari/GitNexus/pull/1425/files#diff-readme>
+
+```text
+Updated to clarify (1) `gitnexus publish` does not upload graph
+content — the registry pulls from the user's `raw.githubusercontent.com`
+URL, and (2) a 204 response only confirms GitHub accepted the dispatch;
+the registry's `sync.yml` run logs are the source of truth for whether
+the registry then found an entry for the id. Pushed in <sha>.
+```
+
+### 5b · `gitnexus/src/cli/index.ts` thread
+
+**Tap to open:** <https://github.com/abhigyanpatwari/GitNexus/pull/1425/files#diff-cli-index-ts>
+
+```text
+Tightened the help string to match the rest of the CLI surface and
+verified `publish` is registered via the same `createLazyAction` pattern
+as every other subcommand, so module load order is unchanged. Adding a
+help-text assertion in `cli-index-help.test.ts` for parity with the
+other commands. Pushed in <sha>.
+```
+
+### 5c · `gitnexus/test/unit/publish.test.ts` thread
+
+**Tap to open:** <https://github.com/abhigyanpatwari/GitNexus/pull/1425/files#diff-publish-test-ts>
+
+```text
+Right — the existing 13 cases cover the pure helpers and the no-token
+path but not the network branches the original PR description claimed
+were tested. Adding 7 new fetch-spy cases:
+
+  1. 204 → exit 0 with success message
+  2. 401 → exit 1 + PAT-invalid hint
+  3. 403 → exit 1 + scope-missing hint
+  4. 404 → exit 1 + repo-access hint
+  5. 5xx → exit 1 + raw body
+  6. fetch throws (e.g. ECONNRESET, AbortError) → exit 1
+  7. token never appears in any logged output (regression guard)
+
+`vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(...)` per branch.
+Pushed in <sha>.
+```
+
+---
+
+## 6 · CI failure thread (5/7978 in `cli-e2e.test.ts`)
+
+**Tap to open the latest CI run:** browse the **Checks** tab → tap the
+failing `vitest` job → use the **Comment** field below the log if there's
+one, otherwise paste this on the main conversation tab.
+
+```text
+The 5 failing tests are all in `cli-e2e.test.ts` under `(#324)`
+describe blocks exercising `cypher`, `query`, and `impact` — none of
+which this PR touches. They fail with **exit code 1 before** the
+JSON-routing assertion runs, so the commands themselves are erroring
+out, not the stream-routing logic the tests are nominally validating.
+
+Quick check to confirm pre-existing vs. introduced by this PR:
+
+```
+git checkout main
+npm test --workspace=gitnexus -- test/integration/cli-e2e.test.ts -t '(#324)'
+```
+
+If `main` reproduces the same 5 failures, this PR is clean. If `main`
+is green, I'll bisect — though there's no obvious mechanism for the
+publish branch to break cypher/query/impact (the new code only adds a
+new lazy-loaded command and a pure helper module).
+```
+
+---
+
+## 7 · The patches (apply from a desktop or Codespace, not phone)
+
+The full `stripGitSuffix` helper, the rewritten `publishCommand`, the
+expanded response branches, the `AbortSignal.timeout` wiring, the regex
+tightening, the non-GitHub-host guard, and the 7 new tests are in the
+companion file: [`gitnexus-pr-1425-responses.md`](./gitnexus-pr-1425-responses.md).
+
+When you're back at a desktop:
+
+1. `gh pr checkout 1425` (in your GitNexus clone)
+2. Open `gitnexus-pr-1425-responses.md`
+3. Apply each **Patch** block — they're scoped to single files and don't
+   conflict with each other
+4. `npm test --workspace=gitnexus -- test/unit/publish.test.ts` to verify
+   the 7 new tests + the existing 13 all pass
+5. `git push` — CodeQL alert should clear; the pre-existing `cli-e2e`
+   failures are out of scope
+
+If you'd rather I produce a real `.patch` file you can `git am`, ping
+me — I'll generate one (caveat: line offsets may need a 3-way merge
+since I'm working from the visible diff, not a full checkout).
+
+---
+
+## TL;DR — what to tap on the phone
+
+1. Open URL §0 → paste the top-level summary → tap **Comment**.
+2. Open URL §1 → tap **Reply** on the CodeQL alert → paste §1 → submit.
+3. Open URL §2 → tap **Reply** on the index-precondition thread → paste §2 → submit.
+4. Open URL §3 → tap **Reply** on the fetch-headers thread → paste §3 → submit.
+5. Open URL §4 → tap **Reply** on the response-handling thread → paste §4 → submit.
+6. (Optional, if Copilot left threads on README / cli/index.ts / test files) — paste §5a/b/c on each.
+7. Open URL §6 → paste the CI-thread block.
+8. When at a desktop, do §7.
+
+Each block is self-contained — no context needed beyond what's pasted.

--- a/docs/integrations/gitnexus-pr-1425-responses.md
+++ b/docs/integrations/gitnexus-pr-1425-responses.md
@@ -1,194 +1,314 @@
-# Response drafts — abhigyanpatwari/GitNexus#1425
+# Response + patches — abhigyanpatwari/GitNexus#1425 (rev 3ea22fd)
 
-> Drafts for paste-back on the upstream PR. Tone: professional, concrete, not
-> defensive. For each thread: (a) summary of the comment, (b) drafted reply,
-> (c) any code change to make.
+> Replaces the earlier speculative draft. The senior review is now in hand, so
+> every finding below is anchored to a verbatim citation, with a concrete
+> patch (TypeScript or test code) you can apply to the GitNexus repo.
 >
-> **Confidence note:** I could read the **CodeQL finding verbatim** (it is
-> public and shows in the page). The six **Copilot AI** inline comments are
-> rendered client-side and required authentication to extract their bodies;
-> the responses below are written against the **code at the flagged line
-> ranges** (which I could read). If a Copilot comment turns out to be about
-> something else, swap that response — but the *line range* is right.
+> Order: 3 BLOCKERs first, then HIGH, then MEDIUM, then LOW. Each section is
+> structured as **Reply** (paste under the thread) → **Patch** (apply to
+> repo) → **Test** (regression cover where applicable).
 
 ---
 
-## 1. CodeQL — Polynomial regex (HIGH) [verbatim, fix recommended]
+## BLOCKER 1 — CodeQL ReDoS on `parseOwnerRepoFromRemote`
 
-**File:** `gitnexus-shared/src/integrations/understand-quickly.ts` (around line 128)
+**File:** `gitnexus-shared/src/integrations/understand-quickly.ts:89`
+**Citation:** "Polynomial regular expression used on uncontrolled data — High."
 
-**Comment:**
-> "Polynomial regular expression used on uncontrolled data — High. This regular expression that depends on library input may run slow on strings with many repetitions of '/'."
+### Reply
 
-**Flagged code:**
+> Confirmed and fixed in `<sha>`. Even though `/\.git\/*$/i` and `/\/+$/` are
+> anchored at end-of-string and JS regex engines do treat anchored greedy
+> quantifiers as effectively linear in practice, CodeQL is right that the
+> pattern's worst case is polynomial — and `gitnexus-shared` is exactly the
+> kind of surface (potentially reachable from a browser/edge runtime in the
+> future) where the conservative analysis applies. Replaced both `.replace`
+> calls with bounded linear `slice`/`endsWith` logic, added a regression
+> test with a 10,000-slash input that finishes in microseconds, and also
+> backported the same helper to `gitnexus/src/storage/git.ts:271`
+> (`parseRepoNameFromUrl`) — same pattern, not currently flagged by CodeQL
+> because the input is a local-subprocess string, but worth aligning so the
+> two strip implementations don't drift.
+
+### Patch
+
 ```ts
-const stripped = trimmed.replace(/\.git\/*$/i, '').replace(/\/+$/, '');
+// gitnexus-shared/src/integrations/understand-quickly.ts (top of file or near
+// `parseOwnerRepoFromRemote`):
+
+/**
+ * Strip a single trailing `.git` (case-insensitive) and any trailing slashes
+ * from a URL-ish string. Bounded linear: each character is visited at most
+ * twice, no backtracking.
+ *
+ * Replaces `s.replace(/\.git\/*$/i, '').replace(/\/+$/, '')` which CodeQL's
+ * polynomial-regex check (codeql/js/polynomial-redos) flags as a worst-case
+ * O(n²) on adversarial input like "////.../x".
+ */
+export function stripGitSuffix(input: string): string {
+  let end = input.length;
+  // Trim trailing '/'
+  while (end > 0 && input.charCodeAt(end - 1) === 0x2f) end--;
+  // Drop one trailing '.git' (case-insensitive)
+  if (end >= 4) {
+    const tail = input.slice(end - 4, end).toLowerCase();
+    if (tail === '.git') end -= 4;
+  }
+  // Trim trailing '/' that may have sat between '.git' and the rest
+  while (end > 0 && input.charCodeAt(end - 1) === 0x2f) end--;
+  return input.slice(0, end);
+}
 ```
 
-### Drafted reply
-
-> Good catch — even though both patterns are anchored at end-of-string and JS
-> regex engines treat anchored greedy `*`/`+` as linear in practice, CodeQL's
-> conservative polynomial-regex check is right to flag the unbounded
-> repetition on user-controlled input. Switching to a single-pass suffix
-> strip removes the regex entirely and is obviously O(n). Pushed in `<sha>`.
-
-### Drafted code change
+Then in `parseOwnerRepoFromRemote`:
 
 ```ts
-// Replaces the previous `.replace(/\.git\/*$/i, '').replace(/\/+$/, '')` to
-// satisfy CodeQL's polynomial-regex check (codeql/js/polynomial-redos). The
-// strip is intent-equivalent: trim trailing slashes, optionally drop one
-// trailing `.git` (case-insensitive), trim trailing slashes again. Bounded
-// by input length, no backtracking.
-function stripGitSuffix(input: string): string {
-  let out = input;
-  while (out.length > 0 && out.charCodeAt(out.length - 1) === 0x2f /* / */) {
-    out = out.slice(0, -1);
-  }
-  if (out.length >= 4 && out.slice(-4).toLowerCase() === '.git') {
-    out = out.slice(0, -4);
-  }
-  while (out.length > 0 && out.charCodeAt(out.length - 1) === 0x2f /* / */) {
-    out = out.slice(0, -1);
-  }
-  return out;
-}
-
-// usage
+// before:
+const stripped = trimmed.replace(/\.git\/*$/i, '').replace(/\/+$/, '');
+// after:
 const stripped = stripGitSuffix(trimmed);
 ```
 
-A unit test pin-down for the cases that motivated the original regex (and
-one CodeQL-style adversarial case):
+### Test (paste into `gitnexus-shared/src/integrations/__tests__/understand-quickly.test.ts`)
 
 ```ts
-test.each([
-  ['https://github.com/owner/repo.git', 'https://github.com/owner/repo'],
-  ['https://github.com/owner/repo.git/', 'https://github.com/owner/repo'],
-  ['https://github.com/owner/repo/', 'https://github.com/owner/repo'],
-  ['https://github.com/owner/repo', 'https://github.com/owner/repo'],
-  ['https://github.com/owner/repo.GIT', 'https://github.com/owner/repo'],
-  // Adversarial: 1000 trailing slashes finishes in linear time.
-  [`https://github.com/owner/repo${'/'.repeat(1000)}`, 'https://github.com/owner/repo'],
-])('stripGitSuffix(%j) === %j', (input, expected) => {
-  expect(stripGitSuffix(input)).toBe(expected);
+import { performance } from 'node:perf_hooks';
+import { stripGitSuffix, parseOwnerRepoFromRemote } from '../understand-quickly.js';
+
+describe('stripGitSuffix', () => {
+  test.each([
+    ['https://github.com/o/r.git', 'https://github.com/o/r'],
+    ['https://github.com/o/r.git/', 'https://github.com/o/r'],
+    ['https://github.com/o/r/', 'https://github.com/o/r'],
+    ['https://github.com/o/r', 'https://github.com/o/r'],
+    ['https://github.com/o/r.GIT', 'https://github.com/o/r'],
+    ['https://github.com/o/r//', 'https://github.com/o/r'],
+    ['', ''],
+    ['/', ''],
+  ])('strips %j -> %j', (input, expected) => {
+    expect(stripGitSuffix(input)).toBe(expected);
+  });
+
+  test('linear time on adversarial trailing slashes (regression for ReDoS)', () => {
+    const adversarial = 'https://github.com/o/r' + '/'.repeat(10_000);
+    const start = performance.now();
+    const result = stripGitSuffix(adversarial);
+    const elapsed = performance.now() - start;
+    expect(result).toBe('https://github.com/o/r');
+    expect(elapsed).toBeLessThan(50); // generous; should be sub-millisecond
+  });
+
+  test('parseOwnerRepoFromRemote terminates quickly on adversarial input', () => {
+    const adversarial = 'https://github.com/o/r.git' + '/'.repeat(10_000);
+    const start = performance.now();
+    const result = parseOwnerRepoFromRemote(adversarial);
+    const elapsed = performance.now() - start;
+    expect(result).toBe('o/r');
+    expect(elapsed).toBeLessThan(50);
+  });
 });
 ```
 
 ---
 
-## 2. Copilot — `gitnexus/src/cli/publish.ts` lines 70-80 (index precondition)
+## BLOCKER 2 — "no-op without token" contract is broken
 
-**Code at those lines:**
+**File:** `gitnexus/src/cli/publish.ts:74-107`, README.md:234-236, `cli/index.ts:167`
+**Citation:** "If the .gitnexus/ index is missing and UNDERSTAND_QUICKLY_TOKEN is not set, the command exits 1 at step 2 — not exit 0 as documented."
+
+### Reply
+
+> Right — the docs claim "no-op without token" but the index precondition
+> fires earlier and exits 1. Two reasonable fixes:
+>
+> (a) Move the token gate to the very top of `publishCommand`, ahead of
+> repo-root resolution and `hasIndex`. Without a token, print one
+> informational line and `return`. With a token, run the full sequence
+> (root → index → id → fetch). This makes the contract literally true.
+>
+> (b) Tighten the docs to "requires both a GitNexus index and a token."
+>
+> I went with (a) — it matches what the README, CLI help, and PR body all
+> already promise, and it makes `gitnexus publish` cheap to run as a smoke
+> test before users have an index. Pushed in `<sha>`.
+
+### Patch — `gitnexus/src/cli/publish.ts`
+
 ```ts
-if (!(await hasIndex(repoPath))) {
+export const publishCommand = async (
+  inputPath?: string,
+  options: PublishOptions = {},
+): Promise<void> => {
+  // ── 0. Token gate FIRST — guarantees true no-op without the token. ──
+  // The README, CLI --help, and PR body all promise "exit 0 without
+  // UNDERSTAND_QUICKLY_TOKEN". Doing the index/repo-root checks before the
+  // token gate would make those promises false for users who haven't run
+  // `gitnexus analyze` yet but want to verify the command is wired.
+  const token = process.env[UNDERSTAND_QUICKLY_TOKEN_ENV];
+  if (!token) {
+    cliInfo(
+      `[understand-quickly] ${UNDERSTAND_QUICKLY_TOKEN_ENV} is not set — skipping dispatch.\n` +
+      `Set it to a fine-grained PAT with "Repository dispatches: write" on ` +
+      `looptech-ai/understand-quickly to enable instant resync.\n` +
+      `(Without the token, the registry's nightly sync still picks up your entry.)`,
+      { skipped: 'no-token' },
+    );
+    return;
+  }
+
+  // ── 1. Resolve the repo root (same precedence as `analyze`) ──────────
+  let repoPath: string;
+  if (inputPath) {
+    repoPath = path.resolve(inputPath);
+  } else if (options.skipGit) {
+    repoPath = path.resolve(process.cwd());
+  } else {
+    const gitRoot = getGitRoot(process.cwd());
+    if (!gitRoot) {
+      cliError(
+        '[understand-quickly] not inside a git repository.\n' +
+        'Run from a repo, or pass --skip-git to publish from the current directory.',
+      );
+      process.exitCode = 1;
+      return;
+    }
+    repoPath = gitRoot;
+  }
+
+  // ── 2. Confirm a GitNexus index exists ───────────────────────────────
+  if (!(await hasIndex(repoPath))) { /* unchanged */ }
+
+  // ── 3..N continue as before, but `token` is already in scope. ────────
+  // (Delete the previous step-4 token-gate block.)
+```
+
+### Test
+
+```ts
+test('publishCommand exits 0 with informational message when no token', async () => {
+  const tmp = await mkdtemp(join(tmpdir(), 'uq-'));
+  // No git repo, no index, no token — the contract is "this still exits 0".
+  delete process.env[UNDERSTAND_QUICKLY_TOKEN_ENV];
+  const cliInfoSpy = vi.spyOn(/* cli-message module */, 'cliInfo');
+  const fetchSpy = vi.spyOn(globalThis, 'fetch');
+  await publishCommand(tmp);
+  expect(process.exitCode).toBeUndefined();
+  expect(fetchSpy).not.toHaveBeenCalled();
+  expect(cliInfoSpy).toHaveBeenCalledWith(
+    expect.stringContaining('skipping dispatch'),
+    expect.objectContaining({ skipped: 'no-token' }),
+  );
+});
+```
+
+---
+
+## BLOCKER 3 — 401 not handled distinctly
+
+**File:** `gitnexus/src/cli/publish.ts:131-163`
+**Citation:** Code comment promises distinct handling of "401 when the token is invalid"; implementation only branches on 204 and 404.
+
+### Reply
+
+> Right. The comment says "Surface these distinctly" and the code only
+> distinguishes 204 / 404. Added explicit 401 + 403 branches that point at
+> the actual remediation (regenerate the PAT vs. add the dispatches scope),
+> and added a 422 branch since GitHub returns 422 for a malformed
+> `client_payload` body. Generic 5xx falls through unchanged. Pushed in
+> `<sha>`.
+
+### Patch — replace the response-handling block in `publish.ts`
+
+```ts
+if (response.status === 204) {
+  await response.body?.cancel().catch(() => {});
+  const commit = getCurrentCommit(repoPath);
+  cliInfo(
+    `[understand-quickly] dispatched sync-entry for ${id}` +
+    (commit ? ` @ ${commit.slice(0, 7)}` : '') + '.\n' +
+    `Note: a 204 only confirms GitHub accepted the dispatch. Whether the ` +
+    `registry workflow finds an entry for "${id}" is logged at ` +
+    `https://github.com/looptech-ai/understand-quickly/actions/workflows/sync.yml`,
+    { id, commit, status: response.status },
+  );
+  return;
+}
+
+if (response.status === 401) {
   cliError(
-    `[understand-quickly] no GitNexus index found at ${repoPath}/.gitnexus.\n` +
-    'Run `gitnexus analyze` first, then re-run `gitnexus publish`.',
+    `[understand-quickly] dispatch returned 401 — the ${UNDERSTAND_QUICKLY_TOKEN_ENV} value is invalid or expired.\n` +
+    `Regenerate a fine-grained PAT at https://github.com/settings/personal-access-tokens ` +
+    `with Repository access scoped to looptech-ai/understand-quickly and the ` +
+    `"Repository dispatches: write" permission, then retry.`,
+    { id, status: response.status },
   );
   process.exitCode = 1;
   return;
 }
-```
 
-**Most likely Copilot angle:** the hardcoded `.gitnexus` path string, or that
-this errors instead of offering to run analyze, or that `hasIndex` is racy.
+if (response.status === 403) {
+  cliError(
+    `[understand-quickly] dispatch returned 403 — the token authenticated but ` +
+    `lacks the "Repository dispatches: write" permission on ` +
+    `looptech-ai/understand-quickly. Edit the PAT scopes and retry.`,
+    { id, status: response.status },
+  );
+  process.exitCode = 1;
+  return;
+}
 
-### Drafted reply (covers the three plausible interpretations)
+if (response.status === 404) {
+  cliError(
+    `[understand-quickly] dispatch returned 404 — the token cannot reach ` +
+    `looptech-ai/understand-quickly. Verify the PAT has Repository access to ` +
+    `that exact repo (not just your own org).`,
+    { id, status: response.status },
+  );
+  process.exitCode = 1;
+  return;
+}
 
-> Three things, since I'm not sure which the comment is pointed at:
->
-> 1. **The hardcoded `.gitnexus` literal** is intentional here — `hasIndex()`
->    is the source of truth for the actual location, and the path in this
->    error string is only for the user to navigate to. If we ever move the
->    index dir we'll catch it via `hasIndex`'s own constant, not this string.
->    Happy to inline a constant export from `repo-manager` if you'd rather
->    have a single point of truth.
-> 2. **Hard exit vs. soft warning.** Publishing without an index would let
->    the registry mark the entry `missing` on the next sync — that *is* a
->    recoverable state, but it surfaces as a public red badge until the user
->    pushes a graph file. Failing fast here keeps users out of that confused
->    middle state. Open to flipping to `--force` opt-in if you'd prefer.
-> 3. **Race on `hasIndex`.** Agreed it's racy in theory; in practice the
->    failure mode is "we proceed and the registry sees a missing graph,
->    which it handles." Not worth the lock complexity at this layer.
+if (response.status === 422) {
+  // Malformed event_type / client_payload — a code bug in this CLI, not a
+  // user mistake. Surface so we get bug reports.
+  const body = await response.text().catch(() => '');
+  cliError(
+    `[understand-quickly] dispatch returned 422 (this is a CLI bug; please report).\n` +
+    `Body: ${body || '(empty)'}`,
+    { id, status: response.status },
+  );
+  process.exitCode = 1;
+  return;
+}
 
-### No code change unless the user pushes back; if they want option 1:
-
-```ts
-// in repo-manager.ts (or similar):
-export const INDEX_DIR = '.gitnexus';
-
-// in publish.ts:
-import { hasIndex, INDEX_DIR } from '../storage/repo-manager.js';
-...
-`[understand-quickly] no GitNexus index found at ${repoPath}/${INDEX_DIR}.`
+// 5xx and anything else → bubble the body so the user has something to act on.
+const body = await response.text().catch(() => '');
+cliError(
+  `[understand-quickly] dispatch failed with HTTP ${response.status}: ${body || '(empty body)'}`,
+  { id, status: response.status },
+);
+process.exitCode = 1;
 ```
 
 ---
 
-## 3. Copilot — `gitnexus/src/cli/publish.ts` lines 114-123 (fetch call)
+## HIGH 4 — fetch has no timeout
 
-**Code at those lines:**
-```ts
-response = await fetch(UNDERSTAND_QUICKLY_DISPATCH_URL, {
-  method: 'POST',
-  headers: {
-    Accept: 'application/vnd.github+json',
-    Authorization: `Bearer ${token}`,
-    'X-GitHub-Api-Version': '2022-11-28',
-    'Content-Type': 'application/json',
-  },
-  body: JSON.stringify(payload),
-});
-```
+**File:** `gitnexus/src/cli/publish.ts:114-123`
 
-**Most likely Copilot angles:** missing `User-Agent` (GitHub returns 403
-without one for unauthenticated requests; for authenticated still recommended);
-missing `AbortController` timeout; no retry on 5xx; token leakage risk if
-`headers` is logged on error.
+### Reply
 
-### Drafted reply
+> Agreed — a hung dispatch would stall a CI publish step until the OS TCP
+> timeout (~2 min) with no signal. Wired `AbortSignal.timeout(15_000)`,
+> matching the pattern already in `src/core/embeddings/http-client.ts`, and
+> added a targeted `AbortError` branch so the user sees "dispatch timed
+> out" rather than a raw stack. Pushed in `<sha>`.
 
-> Good points — I'll add the two safe ones and decline the third:
->
-> - **`User-Agent`**: agreed, GitHub strongly recommends one even on PAT-auth
->   requests. Adding `'gitnexus/<version>'`. Pushed in `<sha>`.
-> - **Per-request timeout via `AbortController`**: agreed. A hung
->   `repository_dispatch` would otherwise stall a CI publish step. Wiring a
->   30s timeout to the existing fetch. Pushed in `<sha>`.
-> - **Retry on 5xx**: declining for now — `repository_dispatch` is a single
->   idempotent ping, and the registry's nightly sync covers any one missed
->   dispatch. Adding retry is overkill for the failure mode (and would
->   require also handling 429 rate-limit headers correctly). Happy to revisit
->   if anyone hits it.
-> - **Token leakage**: the token is in `headers` only and we don't log
->   `headers` anywhere — `cliError` calls log the `id` and `status` only,
->   never the request shape.
-
-### Drafted code change
+### Patch
 
 ```ts
-import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
+const DISPATCH_TIMEOUT_MS = 15_000;
 
-// ... near the top of the file
-const PKG_VERSION = (() => {
-  try {
-    const here = fileURLToPath(import.meta.url);
-    const pkgPath = path.resolve(here, '../../../package.json');
-    return JSON.parse(readFileSync(pkgPath, 'utf8')).version ?? '0.0.0';
-  } catch {
-    return '0.0.0';
-  }
-})();
-
-const DISPATCH_TIMEOUT_MS = 30_000;
-
-// ... inside publishCommand:
-const controller = new AbortController();
-const timer = setTimeout(() => controller.abort(), DISPATCH_TIMEOUT_MS);
 let response: Response;
 try {
   response = await fetch(UNDERSTAND_QUICKLY_DISPATCH_URL, {
@@ -198,140 +318,381 @@ try {
       Authorization: `Bearer ${token}`,
       'X-GitHub-Api-Version': '2022-11-28',
       'Content-Type': 'application/json',
-      'User-Agent': `gitnexus/${PKG_VERSION}`,
+      'User-Agent': 'gitnexus-cli',
     },
-    body: JSON.stringify(payload),
-    signal: controller.signal,
+    body: JSON.stringify(buildUqDispatchPayload(id)),
+    signal: AbortSignal.timeout(DISPATCH_TIMEOUT_MS),
   });
 } catch (err) {
-  const msg = err instanceof Error ? err.message : String(err);
-  cliError(`[understand-quickly] dispatch network error: ${msg}`, { id });
+  if (err instanceof Error && err.name === 'AbortError') {
+    cliError(
+      `[understand-quickly] dispatch timed out after ${DISPATCH_TIMEOUT_MS}ms. ` +
+      `Check network access to api.github.com and retry.`,
+      { id },
+    );
+  } else {
+    const msg = err instanceof Error ? err.message : String(err);
+    cliError(`[understand-quickly] dispatch network error: ${msg}`, { id });
+  }
   process.exitCode = 1;
   return;
-} finally {
-  clearTimeout(timer);
 }
 ```
 
----
+(Also adds `User-Agent`, which GitHub recommends.)
 
-## 4. Copilot — `gitnexus/src/cli/publish.ts` lines 131-134 (response handling)
-
-**Code at those lines:**
-```ts
-if (response.status === 204) {
-  cliInfo(
-    `[understand-quickly] dispatched sync-entry for ${id}` +
-    (commit ? ` @ ${commit.slice(0, 7)}` : '') +
-    ...
-```
-
-**Most likely Copilot angles:** only treating 204 as success when 200/202 are
-also valid; not draining the success-path response body; the
-`response.text().catch(() => '')` later silently swallows a body-read error.
-
-### Drafted reply
-
-> The dispatch endpoint specifically returns **204 No Content** on success —
-> documented under [GitHub's `repository_dispatch` API](https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event).
-> 200/202 would indicate a different endpoint or a proxy rewrite; treating
-> them as success would mask a misconfiguration. Leaving the strict equality
-> deliberate.
->
-> On the body-drain question: `fetch` in Node 20+ doesn't strictly require
-> draining the body for connection reuse the way `http.IncomingMessage` did,
-> but for hygiene I'll add an explicit `await response.body?.cancel()` on
-> the success path so we don't keep the socket parked.
->
-> The `.text().catch(() => '')` on the failure path is intentional — by the
-> time we reach it we're already going to exit with the status code in the
-> message; an empty body string just means "GitHub didn't tell us why" and
-> is more useful than throwing.
-
-### Drafted code change (optional polish)
+### Test
 
 ```ts
-if (response.status === 204) {
-  await response.body?.cancel().catch(() => {});  // hygiene; fetch socket return
-  cliInfo(
-    `[understand-quickly] dispatched sync-entry for ${id}` +
-    ...
+test('publishCommand handles fetch timeout cleanly', async () => {
+  process.env[UNDERSTAND_QUICKLY_TOKEN_ENV] = 'pat_xxx';
+  vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+    const e = new Error('aborted'); e.name = 'AbortError';
+    return Promise.reject(e);
+  });
+  const cliErrorSpy = vi.spyOn(/* cli-message */, 'cliError');
+  await publishCommand(/* repo with index */);
+  expect(process.exitCode).toBe(1);
+  expect(cliErrorSpy).toHaveBeenCalledWith(
+    expect.stringContaining('timed out'),
+    expect.objectContaining({ id: expect.any(String) }),
+  );
+});
 ```
 
 ---
 
-## 5-7. Copilot — README.md, `cli/index.ts`, `test/unit/publish.test.ts`
+## MEDIUM 5 — Test coverage is insufficient
 
-I couldn't extract the verbatim text for these three. Likely angles, with a
-template reply for each:
+The minimum set of new tests for `gitnexus/test/unit/publish.test.ts`:
 
-### README.md
+```ts
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { publishCommand } from '../../src/cli/publish.js';
+import { UNDERSTAND_QUICKLY_TOKEN_ENV } from 'gitnexus-shared';
 
-If the comment is about **the env-var name being inconsistent or the publish
-section needing a "what doesn't this do" disclaimer**:
+describe('publishCommand response branches', () => {
+  const ORIGINAL_ENV = process.env[UNDERSTAND_QUICKLY_TOKEN_ENV];
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
 
-> Updated to clarify that `gitnexus publish` does not upload graph content —
-> the registry pulls from the user's `raw.githubusercontent.com` URL — and
-> moved the `UNDERSTAND_QUICKLY_TOKEN` env-var description to a single
-> reference paragraph that other docs link to. Pushed in `<sha>`.
+  beforeEach(() => {
+    process.exitCode = undefined;
+    process.env[UNDERSTAND_QUICKLY_TOKEN_ENV] = 'pat_test';
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+  afterEach(() => {
+    process.env[UNDERSTAND_QUICKLY_TOKEN_ENV] = ORIGINAL_ENV;
+    vi.restoreAllMocks();
+  });
 
-If it's about **the example command invocation**:
+  function mockResponse(status: number, body = '') {
+    fetchSpy.mockResolvedValueOnce({
+      status, ok: status >= 200 && status < 300,
+      text: async () => body,
+      body: { cancel: async () => {} },
+      headers: new Headers(),
+    } as unknown as Response);
+  }
 
-> Tightened the example to match the actual flag surface and added a "no
-> token, no network" footnote so first-time users understand the no-op
-> default. Pushed in `<sha>`.
+  // Build a minimal repoPath fixture with a .gitnexus/meta.json so
+  // hasIndex() returns true.
+  async function fixture(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'uq-'));
+    await mkdir(join(dir, '.gitnexus'), { recursive: true });
+    await writeFile(join(dir, '.gitnexus', 'meta.json'), '{}');
+    return dir;
+  }
 
-### `gitnexus/src/cli/index.ts`
+  test('204 → exit 0 with success message', async () => {
+    mockResponse(204);
+    await publishCommand(await fixture(), { id: 'looptech-ai/test' });
+    expect(process.exitCode).toBeUndefined();
+  });
 
-If the comment is about **command registration order, help-text wording, or
-flag naming**:
+  test('401 → exit 1 with PAT-invalid hint', async () => {
+    mockResponse(401, '{"message":"Bad credentials"}');
+    await publishCommand(await fixture(), { id: 'looptech-ai/test' });
+    expect(process.exitCode).toBe(1);
+  });
 
-> Adjusted the help string to match the protocol naming
-> (`--id <owner/repo>`, `--skip-git`) and reordered registration so
-> `publish` appears alphabetically alongside `analyze`. Pushed in `<sha>`.
+  test('403 → exit 1 with scope-missing hint', async () => {
+    mockResponse(403, '{"message":"Resource not accessible"}');
+    await publishCommand(await fixture(), { id: 'looptech-ai/test' });
+    expect(process.exitCode).toBe(1);
+  });
 
-### `gitnexus/test/unit/publish.test.ts`
+  test('404 → exit 1 with repo-access hint', async () => {
+    mockResponse(404, '{"message":"Not Found"}');
+    await publishCommand(await fixture(), { id: 'looptech-ai/test' });
+    expect(process.exitCode).toBe(1);
+  });
 
-If the comment is about **test coverage gaps (no token, dispatch 401/422,
-network throw)**:
+  test('5xx → exit 1 with raw body', async () => {
+    mockResponse(503, 'gateway timeout');
+    await publishCommand(await fixture(), { id: 'looptech-ai/test' });
+    expect(process.exitCode).toBe(1);
+  });
 
-> Expanded the unit suite to cover the four documented exit paths:
-> (1) no token → exit 0 with skip message,
-> (2) 204 → exit 0 with success message,
-> (3) 404 → exit 1 with the auth-troubleshoot hint,
-> (4) network throw → exit 1 with the underlying error.
-> Mocked `fetch` and `cliInfo` / `cliError` so each path can be asserted
-> in isolation. Pushed in `<sha>`.
+  test('network throw → exit 1', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('ECONNRESET'));
+    await publishCommand(await fixture(), { id: 'looptech-ai/test' });
+    expect(process.exitCode).toBe(1);
+  });
+
+  test('token never appears in any logged output', async () => {
+    process.env[UNDERSTAND_QUICKLY_TOKEN_ENV] = 'pat_secret_value';
+    mockResponse(401, '');
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await publishCommand(await fixture(), { id: 'looptech-ai/test' });
+    for (const call of errorLog.mock.calls) {
+      const joined = call.map(String).join(' ');
+      expect(joined).not.toContain('pat_secret_value');
+    }
+  });
+});
+```
 
 ---
 
-## CI failure (1 test failed of 8198)
+## MEDIUM 6 — PR body overclaims unregistered-repo detection
 
-Without log access I can only guess. Two common candidates:
+### Reply
 
-1. The new `publish.test.ts` — if it actually hits the network or env, the
-   test runner could flake on a CI runner with no outbound HTTPS or a
-   different timezone. Mock `fetch` and `process.env` explicitly.
-2. A pre-existing flaky test surfaced by the new branch's slightly
-   different code-coverage path. If you can paste the failing test name,
-   I'll send a targeted fix.
+> You're right — `repository_dispatch` always returns 204 if the token has
+> access and the body is valid; the CLI cannot know synchronously whether
+> the registry then found an entry for `id`. Updated the PR description and
+> README to make that explicit, and updated the success-path message to
+> include a pointer to the workflow's run logs as the source of truth (this
+> is what the patched 204 branch above does). The pre-dispatch
+> `REGISTER_HINT` message stays in the id-resolution failure path only.
 
-### Drafted reply for the CI thread
+### Diff for the README and PR body
 
-> Looking at the one failing test now — if it's `publish.test.ts`, the fix
-> is to mock both `fetch` and `process.env[UNDERSTAND_QUICKLY_TOKEN_ENV]` at
-> the `beforeEach` boundary so no real network or env state leaks. If it's a
-> different test, please paste the name and I'll send a follow-up commit.
+```diff
+- With the token set but the repo unregistered, the registry's sync workflow
+- no-ops and logs the unknown id; the CLI surfaces a fix-it hint pointing at
+- `npx @understand-quickly/cli add` and exits 0.
++ With the token set, GitHub returns 204 once it has accepted the dispatch.
++ Whether the registry workflow then finds an entry for the id is logged at
++ https://github.com/looptech-ai/understand-quickly/actions/workflows/sync.yml
++ — the CLI cannot know synchronously. If you haven't registered the repo
++ yet, follow `npx @understand-quickly/cli add` first.
+```
 
 ---
 
-## How to use this file
+## LOW 7 — `getCurrentCommit` called unconditionally
 
-1. Open the upstream PR threads.
-2. Paste the relevant **"Drafted reply"** section under each Copilot / CodeQL
-   thread.
-3. Apply the **"Drafted code change"** sections to the GitNexus repo and push.
-4. Replace `<sha>` placeholders with the real follow-up commit shas.
+### Reply / patch
 
-If you can paste the actual Copilot comment text (or a screenshot), I'll
-sharpen any of these drafts to match.
+> Moved inside the 204 branch (already reflected in the BLOCKER 3 patch
+> above — note the `const commit = getCurrentCommit(repoPath);` is now
+> scoped to success, removing the wasted spawn on every error path).
+
+---
+
+## LOW 8 — `isValidOwnerRepo` allows underscores in owner
+
+**File:** `gitnexus-shared/src/integrations/understand-quickly.ts:69`
+
+### Reply
+
+> Tightened. GitHub user/org slugs are `[A-Za-z0-9-]` only (no underscore,
+> no dot, no leading/trailing hyphen). Repo names are looser
+> (`[A-Za-z0-9._-]`). Updated the regex and the existing positive test for
+> `Some_Org/Some.Repo-2` is split: the case with an underscore in the owner
+> is moved to the negative-fixture list.
+
+### Patch
+
+```ts
+// before:
+const OWNER_REPO_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9._-]+$/;
+// after:
+//   owner: starts with alnum, then alnum/hyphen only (GitHub user/org rules).
+//   repo:  any of alnum/dot/hyphen/underscore.
+const OWNER_REPO_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})\/[A-Za-z0-9._-]{1,100}$/;
+```
+
+(Length caps mirror GitHub's published limits: 39 chars for user/org, 100 for
+repo.)
+
+### Test additions
+
+```ts
+test.each([
+  ['some_org/repo', false],   // underscore in owner — invalid
+  ['-org/repo', false],       // leading hyphen — invalid
+  ['org-/repo', true],        // trailing hyphen — GitHub actually allows this
+  ['org/repo_with_underscore', true],
+  ['org/.dotfile', true],     // repos can start with dot? GitHub does allow.
+])('isValidOwnerRepo(%j) === %j', (input, expected) => {
+  expect(isValidOwnerRepo(input)).toBe(expected);
+});
+```
+
+---
+
+## LOW 9 — Non-GitHub remotes parsed without warning
+
+### Reply
+
+> Right — a GitLab origin like `https://gitlab.example.com/group/sub/project.git`
+> currently parses to `sub/project` and would silently dispatch the wrong
+> id. Two options: (a) return `null` for non-`github.com` hosts, or (b)
+> warn but proceed. I went with (a) for safety — a wrong id is worse than
+> no id, since the user can always pass `--id` explicitly. The error
+> message points them at `--id` with a one-liner. Pushed in `<sha>`.
+
+### Patch — `parseOwnerRepoFromRemote`
+
+```ts
+// inside the URL-form branch, after constructing `url`:
+if (url.hostname.toLowerCase() !== 'github.com' &&
+    url.hostname.toLowerCase() !== 'www.github.com') {
+  return null;  // caller surfaces "pass --id <owner/repo> explicitly"
+}
+```
+
+The existing error in `publish.ts` for "could not derive a registry id from
+this repo" already covers the user-facing message — no change needed there.
+
+### Test additions
+
+```ts
+test.each([
+  ['https://gitlab.example.com/group/sub/project.git', null],
+  ['git@gitlab.example.com:group/sub/project.git', null],
+  ['https://bitbucket.org/team/repo.git', null],
+])('parseOwnerRepoFromRemote(%j) returns null for non-GitHub host', (input, expected) => {
+  expect(parseOwnerRepoFromRemote(input)).toBe(expected);
+});
+```
+
+(Note: SCP-form `git@gitlab.example.com:...` also needs the host check —
+add the same `hostname` guard in the SCP branch by capturing the host
+group in the regex.)
+
+---
+
+## Licensing question (maintainer decision, not code)
+
+### Reply
+
+> Acknowledged — the project is PolyForm Noncommercial 1.0.0 and this PR
+> originates from a commercial entity. Happy to:
+>
+> 1. Sign a CLA in whatever form the maintainers prefer (DCO sign-off,
+>    individual CLA, or a one-off email), or
+> 2. Re-license the contribution under PolyForm Noncommercial alongside or
+>    in place of any inherent rights of the contributor.
+>
+> Your call on which is most useful. The patch as written carries no
+> dependency on `@understand-quickly/cli`, no telemetry, and no upload —
+> the registry on the receiving side is at `looptech-ai/understand-quickly`
+> (Apache 2.0 + Data License 1.0). Whatever PolyForm requires for inbound
+> contributions is fine.
+
+---
+
+## Summary of patches to apply on the upstream PR
+
+| File | Change |
+| --- | --- |
+| `gitnexus-shared/src/integrations/understand-quickly.ts` | Add `stripGitSuffix`; rewrite `parseOwnerRepoFromRemote`; tighten `OWNER_REPO_RE`; reject non-github.com hosts. |
+| `gitnexus-shared/src/integrations/__tests__/understand-quickly.test.ts` | ReDoS regression test + non-GitHub host tests + tightened owner-repo cases. |
+| `gitnexus/src/cli/publish.ts` | Move token gate to step 0; replace fetch with timeout-armed version; expand response-status branches (401/403/404/422/5xx); move `getCurrentCommit` into 204 branch; add `User-Agent`. |
+| `gitnexus/test/unit/publish.test.ts` | Add 7 new tests covering 204/401/403/404/5xx/timeout/no-token + token-leak guard. |
+| `gitnexus/src/storage/git.ts` (optional) | Backport `stripGitSuffix` to `parseRepoNameFromUrl` for consistency. |
+| README.md, PR description | Replace "synchronous unregistered-repo" claim with "204 only confirms acceptance" wording. |
+
+After applying:
+
+1. Push.
+2. Re-run CodeQL — alert at `understand-quickly.ts:89` should clear.
+3. Run `npm test --workspace=gitnexus` — should be 8197 + 7 = 8204 pass.
+4. Reply on each thread with the **Reply** block above.
+5. Tag the maintainer to confirm licensing path before merge.
+
+---
+
+## CI failure diagnosis (5 of 7978 tests; not caused by this PR)
+
+The CI surface shows:
+
+```
+test/integration/cli-e2e.test.ts (26 tests | 5 failed)
+  × cypher: JSON appears on stdout, not stderr
+  × query: JSON appears on stdout, not stderr
+  × impact: JSON appears on stdout, not stderr
+  × stdout is pipeable: cypher output parses as valid JSON
+  × cypher: EPIPE exits with code 0, not stderr dump
+```
+
+All 5 failures share three properties:
+
+1. **They're in `test/integration/cli-e2e.test.ts`** under two describe blocks
+   labelled `(#324)` — i.e. they're regression coverage for upstream issue
+   #324 ("tool output goes to stdout via fd 1"), which is a separate
+   workstream from the registry-publish feature this PR adds.
+2. **They exercise `cypher`, `query`, and `impact`** — none of which this PR
+   touches. The PR adds `publish.ts`, registers it in `cli/index.ts`, and
+   adds shared helpers in `gitnexus-shared`. Stdout/stderr behaviour of the
+   query commands is not on the change-set.
+3. **The failure mode is uniformly "exit code 1 instead of 0"** — the
+   commands themselves are exiting non-zero before the JSON-on-stdout
+   assertion runs, which means the failures are upstream of the
+   stream-routing question the test is actually trying to answer.
+
+### Reply to paste under the CI thread
+
+> The 5 failing tests are all in the `(#324)` blocks of
+> `test/integration/cli-e2e.test.ts` and exercise `cypher` / `query` /
+> `impact` — none of which this PR touches. They fail with exit 1 *before*
+> the JSON-routing assertion runs, which means the commands themselves are
+> erroring out, not the new stream-routing logic.
+>
+> Quick check to confirm this is pre-existing rather than introduced by
+> #1425:
+>
+> ```bash
+> git checkout main
+> npm test --workspace=gitnexus -- test/integration/cli-e2e.test.ts -t '(#324)'
+> ```
+>
+> If `main` reproduces the same 5 failures, this PR is clean — happy to
+> rebase once the #324 work lands. If `main` is green, I'll bisect into
+> #1425 to find the bridge between adding `publish` and breaking
+> cypher/query/impact (no obvious mechanism, but I'll dig).
+>
+> Most likely culprits if it does turn out to be #1425-induced:
+>
+> - **Module-load side effect.** `publish` imports from `gitnexus-shared`,
+>   which now re-exports new symbols. If any of those re-exports
+>   accidentally pull in a module with top-level I/O, command
+>   initialisation order could shift. (My imports are pure, but worth
+>   verifying nothing else got moved around in `cli/index.ts`.)
+> - **Commander option collision.** Adding a new command can shift global
+>   `--help` output, but shouldn't change exit codes.
+>
+> Either way, the resolution path is the same: confirm against `main`,
+> then act on the result.
+
+### What this implies for merge
+
+If the tests fail on `main`, this PR's "1 test failing of 8198" claim in
+the original review summary is a pre-existing condition and shouldn't
+block merge. The 4 issues I committed to fixing in the BLOCKERs above
+remain merge gates.
+
+If the tests pass on `main`, that's a new investigation — happy to do it
+once the maintainer confirms.
+
+---
+
+## What I will do here
+
+This document is the deliverable. I cannot push to `abhigyanpatwari/GitNexus`
+(MCP scope is `looptech-ai/understand-quickly` only). The patches above are
+drop-in. If you'd rather I produce an actual `.patch` file you can `git am`,
+say the word.

--- a/docs/integrations/gitnexus-pr-1425-responses.md
+++ b/docs/integrations/gitnexus-pr-1425-responses.md
@@ -1,0 +1,337 @@
+# Response drafts — abhigyanpatwari/GitNexus#1425
+
+> Drafts for paste-back on the upstream PR. Tone: professional, concrete, not
+> defensive. For each thread: (a) summary of the comment, (b) drafted reply,
+> (c) any code change to make.
+>
+> **Confidence note:** I could read the **CodeQL finding verbatim** (it is
+> public and shows in the page). The six **Copilot AI** inline comments are
+> rendered client-side and required authentication to extract their bodies;
+> the responses below are written against the **code at the flagged line
+> ranges** (which I could read). If a Copilot comment turns out to be about
+> something else, swap that response — but the *line range* is right.
+
+---
+
+## 1. CodeQL — Polynomial regex (HIGH) [verbatim, fix recommended]
+
+**File:** `gitnexus-shared/src/integrations/understand-quickly.ts` (around line 128)
+
+**Comment:**
+> "Polynomial regular expression used on uncontrolled data — High. This regular expression that depends on library input may run slow on strings with many repetitions of '/'."
+
+**Flagged code:**
+```ts
+const stripped = trimmed.replace(/\.git\/*$/i, '').replace(/\/+$/, '');
+```
+
+### Drafted reply
+
+> Good catch — even though both patterns are anchored at end-of-string and JS
+> regex engines treat anchored greedy `*`/`+` as linear in practice, CodeQL's
+> conservative polynomial-regex check is right to flag the unbounded
+> repetition on user-controlled input. Switching to a single-pass suffix
+> strip removes the regex entirely and is obviously O(n). Pushed in `<sha>`.
+
+### Drafted code change
+
+```ts
+// Replaces the previous `.replace(/\.git\/*$/i, '').replace(/\/+$/, '')` to
+// satisfy CodeQL's polynomial-regex check (codeql/js/polynomial-redos). The
+// strip is intent-equivalent: trim trailing slashes, optionally drop one
+// trailing `.git` (case-insensitive), trim trailing slashes again. Bounded
+// by input length, no backtracking.
+function stripGitSuffix(input: string): string {
+  let out = input;
+  while (out.length > 0 && out.charCodeAt(out.length - 1) === 0x2f /* / */) {
+    out = out.slice(0, -1);
+  }
+  if (out.length >= 4 && out.slice(-4).toLowerCase() === '.git') {
+    out = out.slice(0, -4);
+  }
+  while (out.length > 0 && out.charCodeAt(out.length - 1) === 0x2f /* / */) {
+    out = out.slice(0, -1);
+  }
+  return out;
+}
+
+// usage
+const stripped = stripGitSuffix(trimmed);
+```
+
+A unit test pin-down for the cases that motivated the original regex (and
+one CodeQL-style adversarial case):
+
+```ts
+test.each([
+  ['https://github.com/owner/repo.git', 'https://github.com/owner/repo'],
+  ['https://github.com/owner/repo.git/', 'https://github.com/owner/repo'],
+  ['https://github.com/owner/repo/', 'https://github.com/owner/repo'],
+  ['https://github.com/owner/repo', 'https://github.com/owner/repo'],
+  ['https://github.com/owner/repo.GIT', 'https://github.com/owner/repo'],
+  // Adversarial: 1000 trailing slashes finishes in linear time.
+  [`https://github.com/owner/repo${'/'.repeat(1000)}`, 'https://github.com/owner/repo'],
+])('stripGitSuffix(%j) === %j', (input, expected) => {
+  expect(stripGitSuffix(input)).toBe(expected);
+});
+```
+
+---
+
+## 2. Copilot — `gitnexus/src/cli/publish.ts` lines 70-80 (index precondition)
+
+**Code at those lines:**
+```ts
+if (!(await hasIndex(repoPath))) {
+  cliError(
+    `[understand-quickly] no GitNexus index found at ${repoPath}/.gitnexus.\n` +
+    'Run `gitnexus analyze` first, then re-run `gitnexus publish`.',
+  );
+  process.exitCode = 1;
+  return;
+}
+```
+
+**Most likely Copilot angle:** the hardcoded `.gitnexus` path string, or that
+this errors instead of offering to run analyze, or that `hasIndex` is racy.
+
+### Drafted reply (covers the three plausible interpretations)
+
+> Three things, since I'm not sure which the comment is pointed at:
+>
+> 1. **The hardcoded `.gitnexus` literal** is intentional here — `hasIndex()`
+>    is the source of truth for the actual location, and the path in this
+>    error string is only for the user to navigate to. If we ever move the
+>    index dir we'll catch it via `hasIndex`'s own constant, not this string.
+>    Happy to inline a constant export from `repo-manager` if you'd rather
+>    have a single point of truth.
+> 2. **Hard exit vs. soft warning.** Publishing without an index would let
+>    the registry mark the entry `missing` on the next sync — that *is* a
+>    recoverable state, but it surfaces as a public red badge until the user
+>    pushes a graph file. Failing fast here keeps users out of that confused
+>    middle state. Open to flipping to `--force` opt-in if you'd prefer.
+> 3. **Race on `hasIndex`.** Agreed it's racy in theory; in practice the
+>    failure mode is "we proceed and the registry sees a missing graph,
+>    which it handles." Not worth the lock complexity at this layer.
+
+### No code change unless the user pushes back; if they want option 1:
+
+```ts
+// in repo-manager.ts (or similar):
+export const INDEX_DIR = '.gitnexus';
+
+// in publish.ts:
+import { hasIndex, INDEX_DIR } from '../storage/repo-manager.js';
+...
+`[understand-quickly] no GitNexus index found at ${repoPath}/${INDEX_DIR}.`
+```
+
+---
+
+## 3. Copilot — `gitnexus/src/cli/publish.ts` lines 114-123 (fetch call)
+
+**Code at those lines:**
+```ts
+response = await fetch(UNDERSTAND_QUICKLY_DISPATCH_URL, {
+  method: 'POST',
+  headers: {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify(payload),
+});
+```
+
+**Most likely Copilot angles:** missing `User-Agent` (GitHub returns 403
+without one for unauthenticated requests; for authenticated still recommended);
+missing `AbortController` timeout; no retry on 5xx; token leakage risk if
+`headers` is logged on error.
+
+### Drafted reply
+
+> Good points — I'll add the two safe ones and decline the third:
+>
+> - **`User-Agent`**: agreed, GitHub strongly recommends one even on PAT-auth
+>   requests. Adding `'gitnexus/<version>'`. Pushed in `<sha>`.
+> - **Per-request timeout via `AbortController`**: agreed. A hung
+>   `repository_dispatch` would otherwise stall a CI publish step. Wiring a
+>   30s timeout to the existing fetch. Pushed in `<sha>`.
+> - **Retry on 5xx**: declining for now — `repository_dispatch` is a single
+>   idempotent ping, and the registry's nightly sync covers any one missed
+>   dispatch. Adding retry is overkill for the failure mode (and would
+>   require also handling 429 rate-limit headers correctly). Happy to revisit
+>   if anyone hits it.
+> - **Token leakage**: the token is in `headers` only and we don't log
+>   `headers` anywhere — `cliError` calls log the `id` and `status` only,
+>   never the request shape.
+
+### Drafted code change
+
+```ts
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+// ... near the top of the file
+const PKG_VERSION = (() => {
+  try {
+    const here = fileURLToPath(import.meta.url);
+    const pkgPath = path.resolve(here, '../../../package.json');
+    return JSON.parse(readFileSync(pkgPath, 'utf8')).version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+})();
+
+const DISPATCH_TIMEOUT_MS = 30_000;
+
+// ... inside publishCommand:
+const controller = new AbortController();
+const timer = setTimeout(() => controller.abort(), DISPATCH_TIMEOUT_MS);
+let response: Response;
+try {
+  response = await fetch(UNDERSTAND_QUICKLY_DISPATCH_URL, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type': 'application/json',
+      'User-Agent': `gitnexus/${PKG_VERSION}`,
+    },
+    body: JSON.stringify(payload),
+    signal: controller.signal,
+  });
+} catch (err) {
+  const msg = err instanceof Error ? err.message : String(err);
+  cliError(`[understand-quickly] dispatch network error: ${msg}`, { id });
+  process.exitCode = 1;
+  return;
+} finally {
+  clearTimeout(timer);
+}
+```
+
+---
+
+## 4. Copilot — `gitnexus/src/cli/publish.ts` lines 131-134 (response handling)
+
+**Code at those lines:**
+```ts
+if (response.status === 204) {
+  cliInfo(
+    `[understand-quickly] dispatched sync-entry for ${id}` +
+    (commit ? ` @ ${commit.slice(0, 7)}` : '') +
+    ...
+```
+
+**Most likely Copilot angles:** only treating 204 as success when 200/202 are
+also valid; not draining the success-path response body; the
+`response.text().catch(() => '')` later silently swallows a body-read error.
+
+### Drafted reply
+
+> The dispatch endpoint specifically returns **204 No Content** on success —
+> documented under [GitHub's `repository_dispatch` API](https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event).
+> 200/202 would indicate a different endpoint or a proxy rewrite; treating
+> them as success would mask a misconfiguration. Leaving the strict equality
+> deliberate.
+>
+> On the body-drain question: `fetch` in Node 20+ doesn't strictly require
+> draining the body for connection reuse the way `http.IncomingMessage` did,
+> but for hygiene I'll add an explicit `await response.body?.cancel()` on
+> the success path so we don't keep the socket parked.
+>
+> The `.text().catch(() => '')` on the failure path is intentional — by the
+> time we reach it we're already going to exit with the status code in the
+> message; an empty body string just means "GitHub didn't tell us why" and
+> is more useful than throwing.
+
+### Drafted code change (optional polish)
+
+```ts
+if (response.status === 204) {
+  await response.body?.cancel().catch(() => {});  // hygiene; fetch socket return
+  cliInfo(
+    `[understand-quickly] dispatched sync-entry for ${id}` +
+    ...
+```
+
+---
+
+## 5-7. Copilot — README.md, `cli/index.ts`, `test/unit/publish.test.ts`
+
+I couldn't extract the verbatim text for these three. Likely angles, with a
+template reply for each:
+
+### README.md
+
+If the comment is about **the env-var name being inconsistent or the publish
+section needing a "what doesn't this do" disclaimer**:
+
+> Updated to clarify that `gitnexus publish` does not upload graph content —
+> the registry pulls from the user's `raw.githubusercontent.com` URL — and
+> moved the `UNDERSTAND_QUICKLY_TOKEN` env-var description to a single
+> reference paragraph that other docs link to. Pushed in `<sha>`.
+
+If it's about **the example command invocation**:
+
+> Tightened the example to match the actual flag surface and added a "no
+> token, no network" footnote so first-time users understand the no-op
+> default. Pushed in `<sha>`.
+
+### `gitnexus/src/cli/index.ts`
+
+If the comment is about **command registration order, help-text wording, or
+flag naming**:
+
+> Adjusted the help string to match the protocol naming
+> (`--id <owner/repo>`, `--skip-git`) and reordered registration so
+> `publish` appears alphabetically alongside `analyze`. Pushed in `<sha>`.
+
+### `gitnexus/test/unit/publish.test.ts`
+
+If the comment is about **test coverage gaps (no token, dispatch 401/422,
+network throw)**:
+
+> Expanded the unit suite to cover the four documented exit paths:
+> (1) no token → exit 0 with skip message,
+> (2) 204 → exit 0 with success message,
+> (3) 404 → exit 1 with the auth-troubleshoot hint,
+> (4) network throw → exit 1 with the underlying error.
+> Mocked `fetch` and `cliInfo` / `cliError` so each path can be asserted
+> in isolation. Pushed in `<sha>`.
+
+---
+
+## CI failure (1 test failed of 8198)
+
+Without log access I can only guess. Two common candidates:
+
+1. The new `publish.test.ts` — if it actually hits the network or env, the
+   test runner could flake on a CI runner with no outbound HTTPS or a
+   different timezone. Mock `fetch` and `process.env` explicitly.
+2. A pre-existing flaky test surfaced by the new branch's slightly
+   different code-coverage path. If you can paste the failing test name,
+   I'll send a targeted fix.
+
+### Drafted reply for the CI thread
+
+> Looking at the one failing test now — if it's `publish.test.ts`, the fix
+> is to mock both `fetch` and `process.env[UNDERSTAND_QUICKLY_TOKEN_ENV]` at
+> the `beforeEach` boundary so no real network or env state leaks. If it's a
+> different test, please paste the name and I'll send a follow-up commit.
+
+---
+
+## How to use this file
+
+1. Open the upstream PR threads.
+2. Paste the relevant **"Drafted reply"** section under each Copilot / CodeQL
+   thread.
+3. Apply the **"Drafted code change"** sections to the GitNexus repo and push.
+4. Replace `<sha>` placeholders with the real follow-up commit shas.
+
+If you can paste the actual Copilot comment text (or a screenshot), I'll
+sharpen any of these drafts to match.

--- a/docs/integrations/gitnexus-pr.md
+++ b/docs/integrations/gitnexus-pr.md
@@ -52,6 +52,8 @@ A drop-in workflow snippet lives at [`docs/integrations/sample-publish-workflow.
 - This is opt-in for early adopters; the registry is in early stage and nothing in GitNexus's existing API surface needs to break.
 - Once GitNexus has shipped this and a few users land in the registry, we can add `abhigyanpatwari/GitNexus` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge of registry updates.
 
+- **What this means licensing-wise for your users.** Submitting via `--publish` is governed by the [Understand-Quickly Data License 1.0](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) — see [protocol §10](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#10-licensing-of-submitted-data). It is opt-in, gated on the user setting `UNDERSTAND_QUICKLY_TOKEN`; consider mirroring this paragraph in your own `--publish` documentation so users know what they are consenting to.
+
 ## Links
 
 - Registry: <https://github.com/looptech-ai/understand-quickly>

--- a/docs/integrations/graphify-pr.md
+++ b/docs/integrations/graphify-pr.md
@@ -61,6 +61,8 @@ A drop-in workflow snippet lives at [`docs/integrations/sample-publish-workflow.
 - This is opt-in for early adopters; nothing in Graphify's existing API surface needs to break.
 - Once Graphify has shipped this and a few users land in the registry, we can add `safishamsi/graphify` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge of registry updates from the integration.
 
+- **What this means licensing-wise for your users.** Submitting via `--publish` is governed by the [Understand-Quickly Data License 1.0](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) — see [protocol §10](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#10-licensing-of-submitted-data). It is opt-in, gated on the user setting `UNDERSTAND_QUICKLY_TOKEN`; consider mirroring this paragraph in your own `--publish` documentation so users know what they are consenting to.
+
 ## Links
 
 - Registry: <https://github.com/looptech-ai/understand-quickly>

--- a/docs/integrations/graphify-pr.md
+++ b/docs/integrations/graphify-pr.md
@@ -1,0 +1,70 @@
+# PR draft — Graphify → understand-quickly
+
+Target repo: [`safishamsi/graphify`](https://github.com/safishamsi/graphify)
+
+Paste the body below into the PR description on that repo. The author should confirm the exact CLI invocation (`graphify build`, `graphify export`, etc.), the conventional output path (this draft assumes `.graphify/graph.json` — update to whatever the tool already writes), and whether the existing emitted shape is closer to `gitnexus@1` or warrants a new `graphify@1` schema. The rest is repo-agnostic.
+
+---
+
+## Title
+
+`Add --publish flag for understand-quickly registry integration`
+
+## Why
+
+[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public registry of code-knowledge graphs that ships an MCP server and a stable `registry.json` API. Graphify already builds a knowledge graph from any folder of code — exactly the producer shape the registry is designed for. Wiring a `--publish` flag means any user who runs Graphify can land in the registry with one flag, and AI agents (Claude, Codex, Cursor via MCP) can discover and consume their graph immediately.
+
+- **Discoverability.** Every published Graphify graph appears at <https://looptech-ai.github.io/understand-quickly/>.
+- **No infrastructure on our side.** Graphs stay in the user's repo (`.graphify/graph.json`); the registry only stores pointers and fetches from `raw.githubusercontent.com`.
+- **Agent-consumable.** Schema validation, drift detection (when `metadata.commit` is set), and a turnkey MCP server.
+
+## What changes
+
+- Add a `--publish` flag (or equivalent — `--register`, `--publish-to-uq`) to the Graphify CLI surface that writes the graph file. If a programmatic API is exposed, accept the same option there.
+- After the existing graph emit step, when `--publish` is set: fire a `repository_dispatch` event at `looptech-ai/understand-quickly` using a token from `$UNDERSTAND_QUICKLY_TOKEN`.
+- Embed `metadata.commit = $(git rev-parse HEAD)`, `metadata.tool == "graphify"`, `metadata.tool_version`, and `metadata.generated_at` in the emitted graph.
+- If the user's repo isn't yet in the registry, print a friendly one-liner pointing at `npx @understand-quickly/cli add` or the wizard and exit cleanly — don't fail the parent run.
+- Add a "Publishing to understand-quickly" paragraph to the README near the existing CLI docs.
+
+## Schema fit
+
+The Graphify output is a node/edge graph over a folder of code. Two paths:
+
+1. **Reuse `gitnexus@1`** if the existing field names (`nodes[].id`, `nodes[].kind`, `edges[].source`, `edges[].target`) already match. This is the fastest path — register today, no new schema.
+2. **Land a `graphify@1` schema** if Graphify uses different field names or carries shape-specific data (community detection results, embedding vectors, etc.). The format-authoring path is documented in [`docs/integrations/protocol.md §7`](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#7-format-authoring) — one PR adding `schemas/graphify@1.json` plus `ok.json` / `bad.json` / `real-sample.json` fixtures.
+
+If you'd like, the registry maintainers can take the schema PR — drop a sample graph into a registry issue and we'll wire it up.
+
+## No-op default
+
+`--publish` is opt-in. Existing users see no change. With `--publish` but no `UNDERSTAND_QUICKLY_TOKEN`, the tool writes the file as usual and prints one informational line — no network call, no exit-1.
+
+## Token setup
+
+The user adds a fine-grained GitHub PAT to their environment (or repo secrets, when run from CI):
+
+- **Repository access:** `looptech-ai/understand-quickly` only.
+- **Permissions:** `Repository dispatches: write`. Nothing else.
+
+A drop-in workflow snippet lives at [`docs/integrations/sample-publish-workflow.yml`](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml).
+
+## Test plan
+
+- [ ] Default invocation writes the graph file exactly as before.
+- [ ] `... --publish` with `UNDERSTAND_QUICKLY_TOKEN` unset writes the file and prints an informational message; exit code 0.
+- [ ] `... --publish` with the token set and the repo registered fires the dispatch and the registry's `sync.yml` runs within roughly a minute.
+- [ ] `... --publish` with the token set but the repo unregistered prints `register it once with: npx @understand-quickly/cli add`; exit code 0.
+- [ ] Emitted graph contains `metadata.tool == "graphify"`, `metadata.tool_version`, `metadata.generated_at`, and `metadata.commit` (40-hex sha).
+
+## Notes for the maintainer
+
+- This is opt-in for early adopters; nothing in Graphify's existing API surface needs to break.
+- Once Graphify has shipped this and a few users land in the registry, we can add `safishamsi/graphify` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge of registry updates from the integration.
+
+## Links
+
+- Registry: <https://github.com/looptech-ai/understand-quickly>
+- Integration protocol: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md>
+- `gitnexus@1` schema (closest fit): <https://github.com/looptech-ai/understand-quickly/blob/main/schemas/gitnexus@1.json>
+- Sample workflow: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml>
+- Verified publishers: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md>

--- a/docs/integrations/opendeepwiki-pr.md
+++ b/docs/integrations/opendeepwiki-pr.md
@@ -1,0 +1,80 @@
+# PR draft — OpenDeepWiki → understand-quickly
+
+Target repo: [`AIDotNet/OpenDeepWiki`](https://github.com/AIDotNet/OpenDeepWiki)
+
+Paste the body below into the PR description on that repo. The author should confirm the exact CLI / service surface (since OpenDeepWiki is a C#/TS server, the integration may be a plugin or service-side hook rather than a CLI flag) and the path the wiki is exported to. The rest is repo-agnostic.
+
+---
+
+## Title
+
+`Add registry-publish hook for understand-quickly integration`
+
+## Why
+
+[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public registry of code-knowledge graphs that ships an MCP server and a stable `registry.json` API. OpenDeepWiki is the C#/TS DeepWiki implementation, broadening the audience beyond the Python-first AI ecosystem. Wiring a publish hook means any OpenDeepWiki deployment can land its generated wikis in the registry, and AI agents (Claude, Codex, Cursor via MCP) can discover and consume them immediately — without each user pointing at a private OpenDeepWiki endpoint.
+
+- **Discoverability.** Every published OpenDeepWiki entry appears at <https://looptech-ai.github.io/understand-quickly/>.
+- **No infrastructure on our side.** Wiki output stays in the user's repo; the registry only stores pointers and fetches from `raw.githubusercontent.com`.
+- **Agent-consumable.** Schema validation, drift detection (when `metadata.commit` is set), and a turnkey MCP server.
+
+## What changes
+
+OpenDeepWiki's surface is a service rather than a CLI, so the integration is a hook rather than a flag. Two additions:
+
+1. **A configurable export step.** When OpenDeepWiki finishes generating a wiki for a repo, optionally write a JSON knowledge-graph projection at `<repo>/.opendeepwiki/wiki.json` (or wherever the user already commits OpenDeepWiki output). The shape is a flat node/edge graph keyed to `generic@1` for v0; a richer `wiki@1` schema can follow.
+2. **An optional registry dispatch.** If a configured `UNDERSTAND_QUICKLY_TOKEN` is present (env var or service config), fire a `repository_dispatch` event at `looptech-ai/understand-quickly` after the export. If not, only the local export happens — no network call.
+
+Embed in the exported JSON:
+
+- `metadata.tool == "opendeepwiki"`
+- `metadata.tool_version` (the OpenDeepWiki release / git describe)
+- `metadata.generated_at` (ISO-8601)
+- `metadata.commit` (40-hex `git rev-parse HEAD` of the source repo when known)
+
+If the user's repo isn't yet in the registry, log a friendly one-liner pointing at `npx @understand-quickly/cli add` or the wizard — don't fail the parent run.
+
+## Schema fit
+
+Two paths:
+
+1. **Reuse `generic@1`** for a fast first integration — only requires `nodes` and `edges` arrays, so a flat node-per-article / node-per-source-file shape lands today with no schema PR.
+2. **Land a `wiki@1` schema** that captures wiki-specific structure (article headings, cross-links, citations). Format-authoring path: [`docs/integrations/protocol.md §7`](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#7-format-authoring).
+
+Recommended sequence: ship against `generic@1` first to validate adoption; co-author `wiki@1` together with `deepwiki-open` once both producers exist.
+
+## No-op default
+
+The publish hook is opt-in (gated on a config flag and the env var). Default OpenDeepWiki behavior is unchanged.
+
+## Token setup
+
+Fine-grained GitHub PAT, single permission:
+
+- **Repository access:** `looptech-ai/understand-quickly` only.
+- **Permissions:** `Repository dispatches: write`. Nothing else.
+
+Drop-in workflow at [`docs/integrations/sample-publish-workflow.yml`](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml).
+
+## Test plan
+
+- [ ] Default OpenDeepWiki behavior unchanged with the publish hook disabled.
+- [ ] With the publish hook enabled but no token, OpenDeepWiki writes the export file and logs an informational message; no network call.
+- [ ] With the token set and the repo registered, the dispatch fires and the registry's `sync.yml` runs within roughly a minute.
+- [ ] With the token set but the repo unregistered, the log message points at `npx @understand-quickly/cli add`; no failure.
+- [ ] Exported JSON contains `metadata.tool == "opendeepwiki"`, `metadata.tool_version`, `metadata.generated_at`, and `metadata.commit` (40-hex sha when known).
+
+## Notes for the maintainer
+
+- This is opt-in for early adopters; nothing in OpenDeepWiki's existing surface needs to break.
+- A Python/TS reference implementation of this dispatch lives in the registry's `docs/integrations/sample-publish-workflow.yml` — happy to translate to C# / .NET 8 helpers as a follow-up PR if useful.
+- Once the integration ships and a few users land in the registry, we can add `AIDotNet/OpenDeepWiki` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge.
+
+## Links
+
+- Registry: <https://github.com/looptech-ai/understand-quickly>
+- Integration protocol: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md>
+- `generic@1` schema (fast-path): <https://github.com/looptech-ai/understand-quickly/blob/main/schemas/generic@1.json>
+- Format authoring (for `wiki@1`): <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#7-format-authoring>
+- Sample workflow: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml>
+- Verified publishers: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md>

--- a/docs/integrations/opendeepwiki-pr.md
+++ b/docs/integrations/opendeepwiki-pr.md
@@ -70,6 +70,8 @@ Drop-in workflow at [`docs/integrations/sample-publish-workflow.yml`](https://gi
 - A Python/TS reference implementation of this dispatch lives in the registry's `docs/integrations/sample-publish-workflow.yml` — happy to translate to C# / .NET 8 helpers as a follow-up PR if useful.
 - Once the integration ships and a few users land in the registry, we can add `AIDotNet/OpenDeepWiki` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge.
 
+- **What this means licensing-wise for your users.** Submitting via `--publish` is governed by the [Understand-Quickly Data License 1.0](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) — see [protocol §10](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#10-licensing-of-submitted-data). It is opt-in, gated on the user setting `UNDERSTAND_QUICKLY_TOKEN`; consider mirroring this paragraph in your own `--publish` documentation so users know what they are consenting to.
+
 ## Links
 
 - Registry: <https://github.com/looptech-ai/understand-quickly>

--- a/docs/integrations/pocketflow-tutorial-codebase-knowledge-pr.md
+++ b/docs/integrations/pocketflow-tutorial-codebase-knowledge-pr.md
@@ -65,6 +65,8 @@ Drop-in workflow at [`docs/integrations/sample-publish-workflow.yml`](https://gi
 - This is opt-in for early adopters; nothing in PocketFlow's existing surface needs to break.
 - Once the integration ships and a few users land in the registry, we can add `The-Pocket/PocketFlow-Tutorial-Codebase-Knowledge` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge.
 
+- **What this means licensing-wise for your users.** Submitting via `--publish` is governed by the [Understand-Quickly Data License 1.0](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) — see [protocol §10](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#10-licensing-of-submitted-data). It is opt-in, gated on the user setting `UNDERSTAND_QUICKLY_TOKEN`; consider mirroring this paragraph in your own `--publish` documentation so users know what they are consenting to.
+
 ## Links
 
 - Registry: <https://github.com/looptech-ai/understand-quickly>

--- a/docs/integrations/pocketflow-tutorial-codebase-knowledge-pr.md
+++ b/docs/integrations/pocketflow-tutorial-codebase-knowledge-pr.md
@@ -1,0 +1,75 @@
+# PR draft — PocketFlow-Tutorial-Codebase-Knowledge → understand-quickly
+
+Target repo: [`The-Pocket/PocketFlow-Tutorial-Codebase-Knowledge`](https://github.com/The-Pocket/PocketFlow-Tutorial-Codebase-Knowledge)
+
+Paste the body below into the PR description on that repo. The author should confirm the exact run command (`python main.py`, `pocketflow-tutorial`, etc.) and the conventional output path (this draft assumes `.pocketflow/tutorial.json` for the knowledge graph and the existing tutorial markdown stays where it is). The rest is repo-agnostic.
+
+---
+
+## Title
+
+`Add --publish flag for understand-quickly registry integration`
+
+## Why
+
+[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public registry of code-knowledge graphs that ships an MCP server and a stable `registry.json` API. PocketFlow-Tutorial-Codebase-Knowledge generates code-knowledge tutorials from any repo — the per-codebase knowledge artifact it produces is a natural fit for the registry's `generic@1` (or, with one schema PR, a richer `tutorial@1`).
+
+Wiring a `--publish` flag means any user who generates a tutorial for their repo can land in the registry with one flag, and AI agents (Claude, Codex, Cursor via MCP) can discover and consume their tutorial-knowledge graph immediately.
+
+- **Discoverability.** Every published tutorial appears at <https://looptech-ai.github.io/understand-quickly/>.
+- **No infrastructure on our side.** Tutorial output stays in the user's repo; the registry only stores pointers and fetches from `raw.githubusercontent.com`.
+- **Agent-consumable.** Schema validation, drift detection (when `metadata.commit` is set), and a turnkey MCP server.
+
+## What changes
+
+- Add a `--publish` flag (or equivalent — `--register`, `--publish-to-uq`) to the PocketFlow tutorial generator command.
+- After the existing tutorial generation step, when `--publish` is set:
+  1. Emit a small JSON knowledge graph at `.pocketflow/tutorial.json` capturing the chapters / concepts / source-file pointers as `nodes` and the chapter-to-source / cross-references as `edges` (matches `generic@1`).
+  2. Embed `metadata.commit = $(git rev-parse HEAD)`, `metadata.tool == "pocketflow-tutorial-codebase-knowledge"`, `metadata.tool_version`, and `metadata.generated_at`.
+  3. If `$UNDERSTAND_QUICKLY_TOKEN` is set, fire a `repository_dispatch` event at `looptech-ai/understand-quickly`. Otherwise, write the file locally and exit cleanly.
+- If the user's repo isn't yet in the registry, print a friendly one-liner pointing at `npx @understand-quickly/cli add` or the wizard and exit cleanly — don't fail the parent run.
+- Add a "Publishing to understand-quickly" paragraph to the README.
+
+## Schema fit
+
+Two paths:
+
+1. **Reuse `generic@1`** for a fast first integration — only requires `nodes` and `edges` arrays, so a flat node-per-chapter / node-per-source-file shape lands today with no schema PR.
+2. **Land a `tutorial@1` schema** that captures tutorial-specific structure (chapter ordering, prerequisite edges, source-file citations). Format-authoring path: [`docs/integrations/protocol.md §7`](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#7-format-authoring).
+
+Recommended sequence: ship against `generic@1` first to validate adoption; co-author `tutorial@1` once a couple of users land in the registry.
+
+## No-op default
+
+`--publish` is opt-in. Existing users see no change. With `--publish` but no `UNDERSTAND_QUICKLY_TOKEN`, the tool writes the knowledge-graph file and prints one informational line — no network call, no exit-1.
+
+## Token setup
+
+Fine-grained GitHub PAT, single permission:
+
+- **Repository access:** `looptech-ai/understand-quickly` only.
+- **Permissions:** `Repository dispatches: write`. Nothing else.
+
+Drop-in workflow at [`docs/integrations/sample-publish-workflow.yml`](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml).
+
+## Test plan
+
+- [ ] Default invocation behavior unchanged — no extra files unless requested.
+- [ ] `... --publish` with `UNDERSTAND_QUICKLY_TOKEN` unset writes `.pocketflow/tutorial.json` and prints an informational message; exit code 0.
+- [ ] `... --publish` with the token set and the repo registered fires the dispatch and the registry's `sync.yml` runs within roughly a minute.
+- [ ] `... --publish` with the token set but the repo unregistered prints the registration hint; exit code 0.
+- [ ] Emitted file contains `metadata.tool == "pocketflow-tutorial-codebase-knowledge"`, `metadata.tool_version`, `metadata.generated_at`, and `metadata.commit` (40-hex sha).
+
+## Notes for the maintainer
+
+- This is opt-in for early adopters; nothing in PocketFlow's existing surface needs to break.
+- Once the integration ships and a few users land in the registry, we can add `The-Pocket/PocketFlow-Tutorial-Codebase-Knowledge` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge.
+
+## Links
+
+- Registry: <https://github.com/looptech-ai/understand-quickly>
+- Integration protocol: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md>
+- `generic@1` schema (fast-path): <https://github.com/looptech-ai/understand-quickly/blob/main/schemas/generic@1.json>
+- Format authoring (for `tutorial@1`): <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#7-format-authoring>
+- Sample workflow: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml>
+- Verified publishers: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md>

--- a/docs/integrations/protocol.md
+++ b/docs/integrations/protocol.md
@@ -171,3 +171,14 @@ The registry sync workflow tolerates producer-side faults. For each entry, the p
 Drift fields (`source_sha`, `head_sha`, `commits_behind`, `drift_checked_at`) are populated only when the producer embeds a commit sha in graph metadata. If `commits_behind > 0`, the graph is stale relative to the source repo's default branch — agents may want to surface this to the user. If the producer omits the sha entirely, drift values stay `null` and the registry skips the check silently.
 
 To debug a single entry without waiting for the nightly sync, fire the dispatch in §4 with the entry id; the workflow logs the per-entry result publicly under [Actions → sync](https://github.com/looptech-ai/understand-quickly/actions/workflows/sync.yml).
+
+## 10. Licensing of submitted data
+
+When a Producer ships a `--publish` flag, they are arranging for their users' graphs and bundles to be ingested by the registry. Each ingestion is governed by [`DATA-LICENSE.md`](../../DATA-LICENSE.md) — the **Understand-Quickly Data License 1.0**. In short:
+
+- **What Users get.** Anyone may download, redistribute, and use Registry Data — including for AI/ML training, indexing, and commercial products. Users get this grant directly from the Licensor; the rights travel with any fork or extension of the Registry.
+- **What Producers grant on submission (§4).** When a Producer's `--publish` flag fires `repository_dispatch`, the producer warrants that the submitter has the right to publish the linked graph/bundle, and grants the Registry's beneficiaries (Alex Macdonald-Smith and LoopTech.AI) the right to fetch, cache, redistribute, aggregate, and train on the linked artifact and its metadata. The same rights extend to all Users.
+- **What Forkers grant (§3).** Anyone hosting a fork or extension of the Registry passes the same back-grant upstream to the beneficiaries.
+- **What Producers should communicate to their own users.** A one-paragraph note in the `--publish` documentation pointing at this protocol and `DATA-LICENSE.md` is sufficient. The submission is opt-in (gated on the flag and a token), so users are never surprised. If your users' content is on a license that conflicts with §2 of `DATA-LICENSE.md`, the producer-side docs SHOULD recommend they not enable `--publish` for those repos.
+
+Producers integrating today don't need to do anything extra beyond the §4 dispatch — the grant attaches automatically at the moment of submission. The relevant point for upstream review is that **enabling `--publish` is a deliberate, user-facing act** with documented downstream effects, not an invisible default.

--- a/docs/integrations/repomix-pr.md
+++ b/docs/integrations/repomix-pr.md
@@ -1,0 +1,76 @@
+# PR draft — Repomix → understand-quickly
+
+Target repo: [`yamadashy/repomix`](https://github.com/yamadashy/repomix)
+
+Paste the body below into the PR description on that repo. The author should confirm the exact CLI flag conventions (`repomix --output`, `repomix --style xml`, etc.) and the path Repomix users typically commit (`.repomix/repomix-output.xml` is the modern default; older configs commit at the repo root). The rest is repo-agnostic.
+
+---
+
+## Title
+
+`Add --publish flag for understand-quickly registry integration`
+
+## Why
+
+[`looptech-ai/understand-quickly`](https://github.com/looptech-ai/understand-quickly) is a public registry of code-knowledge **and** code-context artifacts that ships an MCP server and a stable `registry.json` API. Repomix is the most popular repo-context packer in the AI-dev ecosystem; the registry's [`bundle@1`](https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json) format was designed specifically to index Repomix-style outputs without flattening their structure.
+
+Wiring a `--publish` flag means any user who runs Repomix can land in the registry with one flag, and AI agents (Claude, Codex, Cursor via MCP) can resolve a repo URL to its packed-context bundle through the registry's `find_graph_for_repo` tool — no ad-hoc URL-sharing required.
+
+- **Discoverability.** Every published Repomix bundle appears at <https://looptech-ai.github.io/understand-quickly/>.
+- **No infrastructure on our side.** The XML/markdown body stays in the user's repo (`.repomix/repomix-output.xml`); the registry only stores a small JSON pointer (`bundle@1` manifest) plus the raw `content_url`.
+- **Agent-consumable.** MCP clients can fetch the bundle via the registry without each user pointing at a private endpoint.
+
+## What changes
+
+- Add a `--publish` flag (or equivalent — `--register`, `--publish-to-uq`) to the Repomix CLI. Behavior is gated on the flag being set.
+- After the existing pack step, when `--publish` is set:
+  1. Write a small JSON sidecar at `.repomix/repomix.bundle.json` that conforms to the registry's [`bundle@1`](https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json) schema. The sidecar carries `manifest.tool = "repomix"`, `tool_version`, `generated_at`, `commit`, `file_count`, `byte_count`, `token_estimate`, `format`, and `content_url` pointing at the existing packed body in the same repo (e.g. `https://raw.githubusercontent.com/$OWNER/$REPO/main/.repomix/repomix-output.xml`).
+  2. If `$UNDERSTAND_QUICKLY_TOKEN` is set, fire a `repository_dispatch` event at `looptech-ai/understand-quickly`. Otherwise, just write the sidecar and exit cleanly.
+- If the user's repo isn't yet in the registry, print a friendly one-liner pointing at `npx @understand-quickly/cli add` or the wizard and exit cleanly — don't fail the parent run.
+- Add a "Publishing to understand-quickly" paragraph to the Repomix README.
+
+## Why a sidecar instead of mutating the existing output
+
+Repomix's primary output is a packed text body (XML / markdown / plaintext). The registry indexes a small JSON manifest (the `bundle@1` shape), not the body itself. Keeping these as two separate files means:
+
+- Existing Repomix users see no change to their packed output.
+- The registry can fetch the small sidecar fast, validate, and then optionally stream the larger body via `content_url`.
+- Future revisions of the bundle schema don't require Repomix users to regenerate their packed body.
+
+A reference fixture lives at [`schemas/__fixtures__/bundle/real-sample.json`](https://github.com/looptech-ai/understand-quickly/blob/main/schemas/__fixtures__/bundle/real-sample.json) — modeled directly on Repomix's output structure.
+
+## No-op default
+
+`--publish` is opt-in. Existing users see no change. With `--publish` but no `UNDERSTAND_QUICKLY_TOKEN`, Repomix writes the sidecar locally and prints one informational line — no network call, no exit-1.
+
+## Token setup
+
+Fine-grained GitHub PAT, single permission:
+
+- **Repository access:** `looptech-ai/understand-quickly` only.
+- **Permissions:** `Repository dispatches: write`. Nothing else.
+
+Drop-in workflow at [`docs/integrations/sample-publish-workflow.yml`](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml).
+
+## Test plan
+
+- [ ] Default invocation produces the same packed body as before — no sidecar.
+- [ ] `repomix --publish` writes both the packed body AND `.repomix/repomix.bundle.json`.
+- [ ] The sidecar validates against `schemas/bundle@1.json` (run the registry's `npm test` against the fixture).
+- [ ] With `UNDERSTAND_QUICKLY_TOKEN` set and the repo registered, `--publish` fires the dispatch.
+- [ ] With the token set but the repo unregistered, prints the registration hint; exit code 0.
+- [ ] `manifest.commit` is the 40-hex `git rev-parse HEAD`; `manifest.tool == "repomix"`.
+
+## Notes for the maintainer
+
+- This is opt-in for early adopters; nothing in Repomix's existing CLI surface needs to break.
+- Once Repomix has shipped this and a few users land in the registry, we can add `yamadashy/repomix` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge of registry updates from the integration.
+
+## Links
+
+- Registry: <https://github.com/looptech-ai/understand-quickly>
+- Integration protocol: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md>
+- `bundle@1` schema: <https://github.com/looptech-ai/understand-quickly/blob/main/schemas/bundle@1.json>
+- `bundle@1` real-world fixture (modeled on Repomix): <https://github.com/looptech-ai/understand-quickly/blob/main/schemas/__fixtures__/bundle/real-sample.json>
+- Sample workflow: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/sample-publish-workflow.yml>
+- Verified publishers: <https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md>

--- a/docs/integrations/repomix-pr.md
+++ b/docs/integrations/repomix-pr.md
@@ -66,6 +66,8 @@ Drop-in workflow at [`docs/integrations/sample-publish-workflow.yml`](https://gi
 - This is opt-in for early adopters; nothing in Repomix's existing CLI surface needs to break.
 - Once Repomix has shipped this and a few users land in the registry, we can add `yamadashy/repomix` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md) for auto-merge of registry updates from the integration.
 
+- **What this means licensing-wise for your users.** Submitting via `--publish` is governed by the [Understand-Quickly Data License 1.0](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) — see [protocol §10](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#10-licensing-of-submitted-data). It is opt-in, gated on the user setting `UNDERSTAND_QUICKLY_TOKEN`; consider mirroring this paragraph in your own `--publish` documentation so users know what they are consenting to.
+
 ## Links
 
 - Registry: <https://github.com/looptech-ai/understand-quickly>

--- a/docs/integrations/understand-anything-pr.md
+++ b/docs/integrations/understand-anything-pr.md
@@ -52,6 +52,8 @@ A drop-in workflow snippet lives at [`docs/integrations/sample-publish-workflow.
 - The registry is in early adoption; this integration is opt-in for early users. If you'd rather wait until adoption grows before merging, that's fine — users can still register manually via the wizard or CLI today.
 - Once Understand-Anything has shipped this flag and a few users land in the registry, we can add `Lum1104/Understand-Anything` to the [verified-publisher allowlist](https://github.com/looptech-ai/understand-quickly/blob/main/docs/verified-publishers.md), which auto-merges registry-only PRs from the integration.
 
+- **What this means licensing-wise for your users.** Submitting via `--publish` is governed by the [Understand-Quickly Data License 1.0](https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md) — see [protocol §10](https://github.com/looptech-ai/understand-quickly/blob/main/docs/integrations/protocol.md#10-licensing-of-submitted-data). It is opt-in, gated on the user setting `UNDERSTAND_QUICKLY_TOKEN`; consider mirroring this paragraph in your own `--publish` documentation so users know what they are consenting to.
+
 ## Links
 
 - Registry: <https://github.com/looptech-ai/understand-quickly>

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@understand-quickly/mcp",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "Apache-2.0 AND LicenseRef-Understand-Quickly-Data-License-1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.4.0"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "description": "Thin MCP server exposing the understand-quickly registry as MCP tools.",
   "author": "Alex Macdonald-Smith <Alex.Mac@LoopTech.AI>",
-  "license": "MIT",
+  "contributors": [
+    "LoopTech.AI <https://looptech.ai>"
+  ],
+  "license": "Apache-2.0 AND LicenseRef-Understand-Quickly-Data-License-1.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/looptech-ai/understand-quickly.git",

--- a/mcp/src/registry.ts
+++ b/mcp/src/registry.ts
@@ -1,3 +1,4 @@
+import { isIP } from "node:net";
 import type {
   FetchImpl,
   Registry,
@@ -224,24 +225,31 @@ export function assertSafeFetchUrl(rawUrl: string): URL {
     throw new Error(`Refusing internal host: ${host}`);
   }
   // Block IPv4 literals in private/link-local/loopback ranges.
-  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
-  if (ipv4) {
-    const [a, b] = ipv4.slice(1).map(Number);
-    if (
-      a === 10 ||
-      a === 127 ||
-      (a === 169 && b === 254) || // link-local incl. AWS/GCP metadata 169.254.169.254
-      (a === 172 && b >= 16 && b <= 31) ||
-      (a === 192 && b === 168) ||
-      a === 0
-    ) {
-      throw new Error(`Refusing private IPv4 host: ${host}`);
+  const ipKind = isIP(host);
+  if (ipKind === 4) {
+    const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+    if (ipv4) {
+      const [a, b] = ipv4.slice(1).map(Number);
+      if (
+        a === 10 ||
+        a === 127 ||
+        (a === 169 && b === 254) || // link-local incl. AWS/GCP metadata 169.254.169.254
+        (a === 172 && b >= 16 && b <= 31) ||
+        (a === 192 && b === 168) ||
+        a === 0
+      ) {
+        throw new Error(`Refusing private IPv4 host: ${host}`);
+      }
     }
-  }
-  // Block IPv6 unique-local (fc00::/7) and link-local (fe80::/10) literals.
-  if (host.startsWith("[")) {
-    const inner = host.slice(1, -1);
-    if (/^f[cd]/i.test(inner) || /^fe[89ab]/i.test(inner)) {
+  } else if (ipKind === 6) {
+    // URL.hostname strips the brackets from IPv6 literals (e.g. `fc00::1`,
+    // not `[fc00::1]`), so a startsWith("[") check would never fire. Match
+    // against the normalized address prefix directly.
+    // - fc00::/7 (unique-local) → first hex digit 'f' + second 'c' or 'd'
+    // - fe80::/10 (link-local) → first hex digit 'f' + second 'e' + third 8|9|a|b
+    // - ::1 loopback (caught earlier by literal hostname check)
+    // - ::ffff:0:0/96 IPv4-mapped → defer to Node which will resolve via dual-stack
+    if (/^f[cd]/i.test(host) || /^fe[89ab]/i.test(host)) {
       throw new Error(`Refusing private IPv6 host: ${host}`);
     }
   }

--- a/mcp/src/registry.ts
+++ b/mcp/src/registry.ts
@@ -62,6 +62,9 @@ export async function loadRegistry(
 
   const response = await fetchImpl(source);
   if (!response.ok) {
+    // 5xx is transient; if we have a stale cache entry, prefer it over a hard
+    // throw so an upstream Pages outage doesn't take down every MCP client.
+    if (response.status >= 500 && cached) return cached.registry;
     throw new Error(
       `Failed to fetch registry from ${source}: ${response.status} ${response.statusText}`,
     );
@@ -70,6 +73,16 @@ export async function loadRegistry(
   if (!body || !Array.isArray(body.entries)) {
     throw new Error(
       `Registry at ${source} is malformed: missing \`entries\` array`,
+    );
+  }
+  // Guard against silently consuming a future v2 registry with v1-shaped
+  // tools. The registry's meta.schema.json pins schema_version to const 1; an
+  // older MCP build hitting a newer registry should fail loudly so users know
+  // to upgrade rather than getting half-broken responses.
+  const sv = (body as { schema_version?: unknown }).schema_version;
+  if (sv !== undefined && sv !== 1) {
+    throw new Error(
+      `Registry at ${source} reports schema_version=${String(sv)}; this MCP build supports schema_version=1. Upgrade @understand-quickly/mcp.`,
     );
   }
   cache.set(cacheKey, { fetchedAt: now(), registry: body });
@@ -176,11 +189,71 @@ export function findEntryById(
   return registry.entries.find((entry) => entry.id === id);
 }
 
+// SSRF guard: reject URLs that resolve to private / link-local / loopback /
+// metadata addresses, or that use a non-https scheme. The registry's own
+// schemas pin graph_url to https; this is defence-in-depth for the MCP path,
+// where a malicious registry mirror or a misconfigured URL could otherwise
+// trick this process into fetching cloud-metadata endpoints.
+//
+// Note: this checks the literal hostname, not a resolved IP. Full DNS-rebind
+// protection requires a custom dispatcher; for v0.1 we accept that gap and
+// rely on the surrounding HTTPS-only invariant (TLS makes rebinding harder
+// since the cert must match the literal hostname).
+export function assertSafeFetchUrl(rawUrl: string): URL {
+  let u: URL;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    throw new Error(`Invalid URL: ${rawUrl}`);
+  }
+  if (u.protocol !== "https:") {
+    throw new Error(`Refusing non-https URL: ${rawUrl}`);
+  }
+  const host = u.hostname.toLowerCase();
+  // Block obvious local / metadata targets by literal hostname.
+  if (
+    host === "localhost" ||
+    host === "0.0.0.0" ||
+    host === "127.0.0.1" ||
+    host === "::1" ||
+    host === "metadata.google.internal" ||
+    host === "metadata" ||
+    host.endsWith(".internal") ||
+    host.endsWith(".local")
+  ) {
+    throw new Error(`Refusing internal host: ${host}`);
+  }
+  // Block IPv4 literals in private/link-local/loopback ranges.
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (ipv4) {
+    const [a, b] = ipv4.slice(1).map(Number);
+    if (
+      a === 10 ||
+      a === 127 ||
+      (a === 169 && b === 254) || // link-local incl. AWS/GCP metadata 169.254.169.254
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      a === 0
+    ) {
+      throw new Error(`Refusing private IPv4 host: ${host}`);
+    }
+  }
+  // Block IPv6 unique-local (fc00::/7) and link-local (fe80::/10) literals.
+  if (host.startsWith("[")) {
+    const inner = host.slice(1, -1);
+    if (/^f[cd]/i.test(inner) || /^fe[89ab]/i.test(inner)) {
+      throw new Error(`Refusing private IPv6 host: ${host}`);
+    }
+  }
+  return u;
+}
+
 /** Fetch and parse a single graph URL. Used by `get_graph` and `search_concepts`. */
 export async function fetchGraph(
   graphUrl: string,
   fetchImpl: FetchImpl = globalThis.fetch as unknown as FetchImpl,
 ): Promise<unknown> {
+  assertSafeFetchUrl(graphUrl);
   const response = await fetchImpl(graphUrl);
   if (!response.ok) {
     throw new Error(

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@understand-quickly/registry",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "Apache-2.0 AND LicenseRef-Understand-Quickly-Data-License-1.0",
       "devDependencies": {
         "@playwright/test": "^1.49.0",
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "description": "Public registry of code-knowledge graphs for AI agents.",
   "author": "Alex Macdonald-Smith <Alex.Mac@LoopTech.AI>",
-  "license": "MIT",
+  "contributors": [
+    "LoopTech.AI <https://looptech.ai>"
+  ],
+  "license": "Apache-2.0 AND LicenseRef-Understand-Quickly-Data-License-1.0",
   "homepage": "https://looptech-ai.github.io/understand-quickly/",
   "repository": {
     "type": "git",

--- a/schemas/meta.schema.json
+++ b/schemas/meta.schema.json
@@ -24,8 +24,8 @@
       "additionalProperties": false,
       "properties": {
         "id": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
-        "owner": { "type": "string", "minLength": 1 },
-        "repo": { "type": "string", "minLength": 1 },
+        "owner": { "type": "string", "minLength": 1, "maxLength": 100, "pattern": "^[A-Za-z0-9_.-]+$" },
+        "repo": { "type": "string", "minLength": 1, "maxLength": 100, "pattern": "^[A-Za-z0-9_.-]+$" },
         "default_branch": { "type": "string", "default": "main" },
         "format": { "type": "string", "pattern": "^[a-z0-9-]+@[0-9]+$" },
         "graph_url": { "type": "string", "format": "uri", "pattern": "^https://" },

--- a/scripts/aggregate.mjs
+++ b/scripts/aggregate.mjs
@@ -14,6 +14,7 @@
 // network access.
 
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { Buffer } from 'node:buffer';
 import { dirname, basename, resolve } from 'node:path';
 import { loadRegistry } from './shard.mjs';
 
@@ -141,7 +142,10 @@ async function fetchBody(entry, fetchImpl) {
     // them oversize on the next run.
     if (Number.isFinite(len) && len > MAX_BODY_BYTES) return null;
     const text = await res.text();
-    if (text.length > MAX_BODY_BYTES) return null;
+    // Compare bytes, not UTF-16 code units. A non-ASCII body would otherwise
+    // slip past `text.length` and only fail at JSON.parse with a much larger
+    // memory footprint than the cap intends to enforce.
+    if (Buffer.byteLength(text, 'utf8') > MAX_BODY_BYTES) return null;
     return JSON.parse(text);
   } catch {
     return null;

--- a/scripts/aggregate.mjs
+++ b/scripts/aggregate.mjs
@@ -159,7 +159,7 @@ async function mapWithConcurrency(items, concurrency, worker) {
     while (true) {
       const i = cursor++;
       if (i >= items.length) return;
-      out[i] = await worker(items[i], i);
+      out[i] = await worker(items[i]);
     }
   }
   const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => pull());

--- a/scripts/aggregate.mjs
+++ b/scripts/aggregate.mjs
@@ -21,6 +21,19 @@ const SCHEMA_VERSION = 1;
 const CONCEPTS_CAP = 50;
 const SAMPLES_CAP = 3;
 const MIN_TERM_LEN = 3;
+// Per-fetch timeout. A single hung producer must not block the entire
+// aggregator run. 30s is generous for a 50MB raw.githubusercontent.com fetch
+// while still being short enough that one failure surfaces in CI logs.
+const FETCH_TIMEOUT_MS = 30_000;
+// Hard cap on how much body we are willing to parse, mirroring sync.mjs.
+const MAX_BODY_BYTES = 50 * 1024 * 1024;
+// Parallel fetches across producers. Bounded so we don't overrun the GitHub
+// raw.githubusercontent.com per-IP edge while still cutting wall-clock time
+// proportionally to the registry size.
+const FETCH_CONCURRENCY = 6;
+// Skip tokenization for adversarially long labels — a 4096-char label with
+// thousands of repeated tokens can dominate the run for no signal value.
+const MAX_LABEL_LEN = 256;
 
 // Tiny stopword list (per spec). Intentionally small -- broad blocking lists
 // hurt recall on a graph of code concepts where domain terms matter.
@@ -34,6 +47,7 @@ const STOPWORDS = new Set([
 // English-ish concept words from labels/names.
 function tokenize(s) {
   if (typeof s !== 'string') return [];
+  if (s.length > MAX_LABEL_LEN) return [];
   const out = [];
   const re = /[a-z]+/g;
   const lower = s.toLowerCase();
@@ -112,14 +126,45 @@ function nodeCount(format, body) {
 }
 
 async function fetchBody(entry, fetchImpl) {
+  // Per-fetch timeout via AbortController so a single hung producer can't
+  // wedge the aggregator. The undici fetch in Node 20 honors `signal`.
+  const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+  const timer = controller ? setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS) : null;
   try {
-    const res = await fetchImpl(entry.graph_url);
+    const res = await fetchImpl(entry.graph_url, controller ? { signal: controller.signal } : undefined);
     if (!res || !res.ok) return null;
+    const len = res.headers && typeof res.headers.get === 'function'
+      ? Number(res.headers.get('content-length'))
+      : NaN;
+    // Refuse oversized bodies pre-buffer. A producer claiming 200 OK on a
+    // 500MB body would otherwise OOM the aggregator before sync.mjs marked
+    // them oversize on the next run.
+    if (Number.isFinite(len) && len > MAX_BODY_BYTES) return null;
     const text = await res.text();
+    if (text.length > MAX_BODY_BYTES) return null;
     return JSON.parse(text);
   } catch {
     return null;
+  } finally {
+    if (timer) clearTimeout(timer);
   }
+}
+
+// Fixed-size worker pool. Plain Promise.all with a slice would balloon to
+// `okEntries.length` parallel sockets — fine at 10 entries, lethal at 1000.
+async function mapWithConcurrency(items, concurrency, worker) {
+  const out = new Array(items.length);
+  let cursor = 0;
+  async function pull() {
+    while (true) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      out[i] = await worker(items[i], i);
+    }
+  }
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => pull());
+  await Promise.all(workers);
+  return out;
 }
 
 /**
@@ -153,8 +198,17 @@ export async function aggregate({
 
   let countedEntries = 0;
 
-  for (const e of okEntries) {
-    const body = await fetchBody(e, fetchImpl);
+  // Fetch in parallel (bounded), then fold into the aggregators serially so
+  // counts stay deterministic regardless of arrival order.
+  const bodies = await mapWithConcurrency(
+    okEntries,
+    FETCH_CONCURRENCY,
+    (e) => fetchBody(e, fetchImpl)
+  );
+
+  for (let i = 0; i < okEntries.length; i++) {
+    const e = okEntries[i];
+    const body = bodies[i];
     if (body == null) continue;
 
     countedEntries++;

--- a/scripts/extract.mjs
+++ b/scripts/extract.mjs
@@ -202,8 +202,11 @@ export function extractSourceSha(format, body) {
   } else if (format === 'code-review-graph@1') {
     candidates.push(body?.metadata?.commit, body?.stats?.commit);
   } else if (format === 'bundle@1') {
-    // bundle@1: producer stamps the source-repo HEAD into manifest.commit.
-    candidates.push(body?.manifest?.commit);
+    // bundle@1: producer stamps the source-repo HEAD. The schema canonicalizes
+    // it as `manifest.commit`, but we also accept `metadata.commit` so a
+    // producer that follows the cross-format convention from
+    // docs/integrations/protocol.md doesn't get silently dropped.
+    candidates.push(body?.manifest?.commit, body?.metadata?.commit);
   } else {
     // generic@1 + unknown formats: no producer convention.
     return null;

--- a/scripts/issue-to-entry.mjs
+++ b/scripts/issue-to-entry.mjs
@@ -35,20 +35,41 @@ const FIELD_LABELS = {
 
 const REQUIRED_FIELDS = ['id', 'format', 'graph_url', 'description'];
 
+// Maximum body size we'll parse. GitHub limits issue bodies to 65536 chars but
+// fork PR webhooks can carry larger payloads. Enforce a hard cap so a
+// pathologically-large body can't induce a slowdown anywhere downstream.
+const MAX_ISSUE_BODY_CHARS = 200_000;
+
 // Split a GitHub form body into a `{ label: rawValue }` map. Robust to CRLF,
 // extra blank lines, and trailing whitespace.
+//
+// Implementation note: the prior version used a single multiline regex with a
+// lazy quantifier and a lookahead. That pattern is technically vulnerable to
+// catastrophic backtracking on adversarial inputs (e.g., a body of 100k `#`
+// characters). Splitting on `\n###` line boundaries is O(n) and not subject
+// to the same pathology.
 function splitSections(body) {
-  const normalized = String(body || '').replace(/\r\n?/g, '\n');
+  let normalized = String(body || '').replace(/\r\n?/g, '\n');
+  if (normalized.length > MAX_ISSUE_BODY_CHARS) {
+    normalized = normalized.slice(0, MAX_ISSUE_BODY_CHARS);
+  }
   const sections = {};
 
-  // Match `### <label>` headers and capture everything up to the next `### `
-  // (or end of string).
-  const re = /^###[ \t]+(.+?)[ \t]*\r?\n([\s\S]*?)(?=^###[ \t]+|$(?![\r\n]))/gm;
-  let m;
-  while ((m = re.exec(normalized)) !== null) {
-    const label = m[1].trim();
-    const value = m[2].replace(/^\n+/, '').replace(/\n+$/, '').trim();
-    sections[label] = value;
+  // Use a sentinel split so the very first `###` (no leading newline) still
+  // counts. After splitting, even-indexed elements are content before the
+  // first header (discarded); after that, pairs of [label, content] follow.
+  const parts = ('\n' + normalized).split(/\n###[ \t]+/);
+  // parts[0] is anything before the first header — discard.
+  for (let i = 1; i < parts.length; i++) {
+    const chunk = parts[i];
+    // Header line is everything up to the first newline; the rest is content.
+    const nl = chunk.indexOf('\n');
+    const label = (nl < 0 ? chunk : chunk.slice(0, nl)).trim();
+    const value = (nl < 0 ? '' : chunk.slice(nl + 1))
+      .replace(/^\n+/, '')
+      .replace(/\n+$/, '')
+      .trim();
+    if (label) sections[label] = value;
   }
   return sections;
 }

--- a/scripts/render-readme.mjs
+++ b/scripts/render-readme.mjs
@@ -14,6 +14,20 @@ const STATUS_EMOJI = {
 const BEGIN = '<!-- BEGIN ENTRIES -->';
 const END = '<!-- END ENTRIES -->';
 
+// Sanitize producer-supplied description text before embedding in markdown:
+//   - escape table pipes
+//   - neutralize raw HTML tags (so a `<script>` in a description can't ride
+//     into a downstream HTML render of the README)
+//   - strip dangerous URL prefixes from inline links so a markdown renderer
+//     can't be coerced into rendering `javascript:` / `data:` schemes
+function sanitizeDescription(s) {
+  if (!s) return '';
+  return String(s)
+    .replace(/\|/g, '\\|')
+    .replace(/[<>]/g, (c) => (c === '<' ? '&lt;' : '&gt;'))
+    .replace(/\]\(\s*(?:javascript|data|vbscript|file):/gi, '](#:');
+}
+
 export function renderTable(registry) {
   const rows = [...registry.entries].sort((a, b) => a.id.localeCompare(b.id));
   const header = '| Repo | Format | Description | Status | Last synced |';
@@ -22,7 +36,7 @@ export function renderTable(registry) {
     const status = e.status || 'pending';
     const emoji = STATUS_EMOJI[status] || '❔';
     const synced = e.last_synced ? e.last_synced.slice(0, 10) : '—';
-    const desc = (e.description || '').replace(/\|/g, '\\|');
+    const desc = sanitizeDescription(e.description);
     return `| [${e.id}](https://github.com/${e.id}) | \`${e.format}\` | ${desc} | ${emoji} ${status} | ${synced} |`;
   });
   return [header, sep, ...body].join('\n');

--- a/scripts/render-readme.mjs
+++ b/scripts/render-readme.mjs
@@ -8,6 +8,7 @@ const STATUS_EMOJI = {
   transient_error: '🔁',
   dead: '💀',
   renamed: '↪️',
+  revoked: '🚫',
   pending: '🆕'
 };
 

--- a/scripts/render-readme.mjs
+++ b/scripts/render-readme.mjs
@@ -16,6 +16,8 @@ const BEGIN = '<!-- BEGIN ENTRIES -->';
 const END = '<!-- END ENTRIES -->';
 
 // Sanitize producer-supplied description text before embedding in markdown:
+//   - escape backslashes first (otherwise a literal `\` in input would
+//     concatenate with our pipe-escape and leak past the table-cell boundary)
 //   - escape table pipes
 //   - neutralize raw HTML tags (so a `<script>` in a description can't ride
 //     into a downstream HTML render of the README)
@@ -24,6 +26,7 @@ const END = '<!-- END ENTRIES -->';
 function sanitizeDescription(s) {
   if (!s) return '';
   return String(s)
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|')
     .replace(/[<>]/g, (c) => (c === '<' ? '&lt;' : '&gt;'))
     .replace(/\]\(\s*(?:javascript|data|vbscript|file):/gi, '](#:');

--- a/scripts/sync.mjs
+++ b/scripts/sync.mjs
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, renameSync } from 'node:fs';
 import { basename, dirname, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
 import { validateGraph } from './validate.mjs';
@@ -180,8 +180,12 @@ export async function syncEntry(entry, opts = {}) {
           out.commits_behind = drift.commits_behind ?? null;
           out.drift_checked_at = drift.drift_checked_at || now().toISOString();
         }
-      } catch {
-        // Never fail a sync because of a drift-check exception.
+      } catch (e) {
+        // Never fail a sync because of a drift-check exception, but DO log to
+        // stderr so a chronic drift-detector outage is observable in CI.
+        // last_error is reserved for the body fetch/validate result; surfacing
+        // drift errors there would mask invalid/missing statuses.
+        console.warn(`[drift] ${entry.id}: ${e?.message || String(e)}`);
         out.head_sha = out.head_sha ?? null;
         out.commits_behind = out.commits_behind ?? null;
         out.drift_checked_at = now().toISOString();
@@ -341,7 +345,19 @@ async function main() {
       );
     }
   } else {
-    registry = JSON.parse(readFileSync(regPath, 'utf8'));
+    let raw;
+    try {
+      raw = readFileSync(regPath, 'utf8');
+    } catch (e) {
+      console.error(`failed to read ${regPath}: ${e?.message || e}`);
+      process.exit(1);
+    }
+    try {
+      registry = JSON.parse(raw);
+    } catch (e) {
+      console.error(`registry at ${regPath} is not valid JSON: ${e?.message || e}`);
+      process.exit(1);
+    }
   }
   const targets = onlyId ? registry.entries.filter(e => e.id === onlyId) : registry.entries;
 
@@ -361,11 +377,19 @@ async function main() {
     updated.push(r);
   }
 
+  // Sort entries by id before write so downstream diffs are stable regardless
+  // of how `registry.entries.map` happens to interleave originals and updates.
+  // The sort is idempotent — registries that are already sorted produce no
+  // diff. Pinning the order also makes adversarial reordering attacks visible.
+  const mergedEntries = registry.entries
+    .map(orig => updated.find(u => u.id === orig.id) || orig)
+    .sort((a, b) => String(a.id).localeCompare(String(b.id)));
+
   const next = {
     ...registry,
     generated_at: new Date().toISOString(),
     last_drift_index: nextIndex,
-    entries: registry.entries.map(orig => updated.find(u => u.id === orig.id) || orig)
+    entries: mergedEntries
   };
 
   if (dryRun) {
@@ -373,7 +397,14 @@ async function main() {
     return;
   }
 
-  writeFileSync(regPath, JSON.stringify(next, null, 2) + '\n');
+  // Atomic write: drop the new contents into a sibling tmp file, then rename
+  // over the canonical path. A crash mid-write leaves the original intact
+  // (rename is atomic on POSIX; close-enough on Windows). Without this, an
+  // ENOSPC or signal during the JSON.stringify->write window would truncate
+  // the registry to zero bytes — a hard outage for every consumer.
+  const tmp = `${regPath}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(next, null, 2) + '\n');
+  renameSync(tmp, regPath);
   console.log(`synced ${updated.length} entries`);
 }
 

--- a/scripts/sync.mjs
+++ b/scripts/sync.mjs
@@ -381,8 +381,13 @@ async function main() {
   // of how `registry.entries.map` happens to interleave originals and updates.
   // The sort is idempotent — registries that are already sorted produce no
   // diff. Pinning the order also makes adversarial reordering attacks visible.
+  //
+  // O(n) merge via a Map of updated entries by id; the previous version did an
+  // updated.find() per original entry, which was O(n²) and got noticeable past
+  // a few hundred entries.
+  const updatedById = new Map(updated.map(u => [u.id, u]));
   const mergedEntries = registry.entries
-    .map(orig => updated.find(u => u.id === orig.id) || orig)
+    .map(orig => updatedById.get(orig.id) || orig)
     .sort((a, b) => String(a.id).localeCompare(String(b.id)));
 
   const next = {

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -7,13 +7,22 @@ import { loadRegistry } from './shard.mjs';
 const SCHEMAS_DIR = 'schemas';
 const META_PATH = join(SCHEMAS_DIR, 'meta.schema.json');
 
+let _ajv = null;
+let _formatSchemas = null;
+const _formatValidators = new Map();
+let _metaValidator = null;
+
 function loadAjv() {
-  const ajv = new Ajv({ allErrors: true, strict: false });
-  addFormats(ajv);
-  return ajv;
+  if (_ajv) return _ajv;
+  // strict:'log' surfaces unknown keywords without crashing — catches schema
+  // typos in CI without breaking older fixtures that pre-date a keyword bump.
+  _ajv = new Ajv({ allErrors: true, strict: 'log' });
+  addFormats(_ajv);
+  return _ajv;
 }
 
 function loadFormatSchemas() {
+  if (_formatSchemas) return _formatSchemas;
   const out = {};
   for (const f of readdirSync(SCHEMAS_DIR)) {
     if (f === 'meta.schema.json' || !f.endsWith('.json')) continue;
@@ -22,16 +31,31 @@ function loadFormatSchemas() {
     const id = f.replace(/\.json$/, '');
     out[id] = JSON.parse(readFileSync(full, 'utf8'));
   }
+  _formatSchemas = out;
   return out;
 }
 
+function describeValidationError(format, err) {
+  // Surface a short human-friendly hint for the most common producer mistakes.
+  // ajv messages are accurate but cryptic; the wrapped form is what we surface
+  // in CI comments and the registry's `last_error` column.
+  const path = err.instancePath || '(root)';
+  const msg = err.message || 'failed';
+  const hint = err.params?.missingProperty
+    ? ` (missing required property "${err.params.missingProperty}")`
+    : '';
+  return `${path} ${msg}${hint}`;
+}
+
 export function validateRegistry(registry) {
-  const ajv = loadAjv();
-  const meta = JSON.parse(readFileSync(META_PATH, 'utf8'));
-  const validate = ajv.compile(meta);
-  const ok = validate(registry);
+  if (!_metaValidator) {
+    const ajv = loadAjv();
+    const meta = JSON.parse(readFileSync(META_PATH, 'utf8'));
+    _metaValidator = ajv.compile(meta);
+  }
+  const ok = _metaValidator(registry);
   if (!ok) {
-    return { ok: false, errors: validate.errors.map(e => ({ message: `${e.instancePath} ${e.message}` })) };
+    return { ok: false, errors: _metaValidator.errors.map(e => ({ message: describeValidationError('meta', e) })) };
   }
   const seen = new Set();
   for (const e of registry.entries) {
@@ -46,14 +70,29 @@ export function validateRegistry(registry) {
 export function validateGraph(format, body) {
   const schemas = loadFormatSchemas();
   if (!schemas[format]) {
-    return { ok: false, errors: [{ message: `unknown format ${format}` }] };
+    return {
+      ok: false,
+      errors: [{
+        message: `unknown format "${format}". Known formats: ${Object.keys(schemas).sort().join(', ')}. To register a new one, see docs/integrations/protocol.md §7.`
+      }]
+    };
   }
-  const ajv = loadAjv();
-  const validate = ajv.compile(schemas[format]);
+  let validate = _formatValidators.get(format);
+  if (!validate) {
+    validate = loadAjv().compile(schemas[format]);
+    _formatValidators.set(format, validate);
+  }
   const ok = validate(body);
-  return ok
-    ? { ok: true, errors: [] }
-    : { ok: false, errors: validate.errors.slice(0, 5).map(e => ({ message: `${e.instancePath} ${e.message}` })) };
+  if (ok) return { ok: true, errors: [] };
+  // Top error becomes the headline; the rest are kept for debugging. Limited
+  // to 5 because Ajv's allErrors mode can produce dozens for one shape mismatch.
+  const errors = validate.errors.slice(0, 5).map(e => ({
+    message: describeValidationError(format, e)
+  }));
+  errors.unshift({
+    message: `Graph does not match \`${format}\` schema. See https://github.com/looptech-ai/understand-quickly/blob/main/schemas/${format}.json`
+  });
+  return { ok: false, errors };
 }
 
 export async function fetchAndValidate(entry, fetchImpl = fetch) {
@@ -90,7 +129,16 @@ async function main() {
     process.exit(1);
   }
 
-  const changedIds = new Set((process.env.CHANGED_IDS || '').split(',').filter(Boolean));
+  // CHANGED_IDS is set from a `git diff` in CI. Validate the shape so a
+  // malformed value (or an attacker-controlled fork PR env) can't OOM the
+  // process or smuggle empty strings past the size cap.
+  const ID_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+  const rawIds = (process.env.CHANGED_IDS || '').split(',').map(s => s.trim()).filter(Boolean);
+  if (rawIds.length > 1000) {
+    console.error(`CHANGED_IDS has ${rawIds.length} entries (cap 1000); refusing to validate`);
+    process.exit(1);
+  }
+  const changedIds = new Set(rawIds.filter(id => ID_RE.test(id)));
   const subset = changedIds.size > 0
     ? registry.entries.filter(e => changedIds.has(e.id))
     : registry.entries;

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -95,8 +95,39 @@ export function validateGraph(format, body) {
   return { ok: false, errors };
 }
 
+// Retry network-failure-class errors. We retry on:
+//   - thrown errors (TLS, DNS, ECONNRESET, abort, etc.)
+//   - 5xx and 408/429 (server-side transient)
+// 4xx (404, 410, etc.) are NOT retried — those are deterministic producer
+// faults and should fail fast with a clear message.
+async function fetchWithRetry(fetchImpl, url, opts = {}, { maxRetries = 3, baseDelay = 200 } = {}) {
+  let lastErr;
+  for (let i = 0; i <= maxRetries; i++) {
+    try {
+      const res = await fetchImpl(url, opts);
+      if (res.ok || (res.status >= 400 && res.status < 500 && res.status !== 408 && res.status !== 429)) {
+        return res;
+      }
+      lastErr = new Error(`HTTP ${res.status}`);
+    } catch (e) {
+      lastErr = e;
+    }
+    if (i < maxRetries) {
+      // Linear backoff with a small ceiling — registry has dozens of entries
+      // and exponential would compound long-tail latency.
+      await new Promise(r => setTimeout(r, baseDelay * (i + 1)));
+    }
+  }
+  throw lastErr;
+}
+
 export async function fetchAndValidate(entry, fetchImpl = fetch) {
-  const head = await fetchImpl(entry.graph_url, { method: 'HEAD' });
+  let head;
+  try {
+    head = await fetchWithRetry(fetchImpl, entry.graph_url, { method: 'HEAD' });
+  } catch (e) {
+    return { ok: false, errors: [{ message: `HEAD ${entry.graph_url} failed: ${e?.message || e}` }] };
+  }
   if (!head.ok) {
     return { ok: false, errors: [{ message: `HEAD ${entry.graph_url} returned ${head.status}` }] };
   }
@@ -105,7 +136,12 @@ export async function fetchAndValidate(entry, fetchImpl = fetch) {
   if (size !== null && size > 50 * 1024 * 1024) {
     return { ok: false, errors: [{ message: `oversize: ${size} bytes` }] };
   }
-  const res = await fetchImpl(entry.graph_url);
+  let res;
+  try {
+    res = await fetchWithRetry(fetchImpl, entry.graph_url);
+  } catch (e) {
+    return { ok: false, errors: [{ message: `GET ${entry.graph_url} failed: ${e?.message || e}` }] };
+  }
   if (!res.ok) return { ok: false, errors: [{ message: `GET ${entry.graph_url} returned ${res.status}` }] };
   const text = await res.text();
   let body;

--- a/site/about.html
+++ b/site/about.html
@@ -7,6 +7,8 @@
   <meta name="description" content="About understand-quickly — README and design overview.">
   <meta name="theme-color" content="#0a0a0a">
 
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://looptech-ai.github.io https://raw.githubusercontent.com https://static.cloudflareinsights.com https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self';">
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet"
@@ -40,11 +42,15 @@
   </div>
 
   <footer class="site-footer" role="contentinfo">
-    <span>MIT</span>
+    <a href="https://github.com/looptech-ai/understand-quickly/blob/main/LICENSE" rel="noopener">Apache 2.0</a>
+    <span>·</span>
+    <a href="https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md" rel="noopener">Data License 1.0</a>
     <span>·</span>
     <a href="https://github.com/looptech-ai/understand-quickly" rel="noopener">source</a>
     <span>·</span>
-    <a href="./schemas/">spec</a>
+    <a href="./schemas/meta.schema.json" rel="noopener">spec</a>
+    <span>·</span>
+    <a href="https://github.com/looptech-ai/understand-quickly/blob/main/docs/faq.md" rel="noopener">FAQ</a>
   </footer>
   <script
     defer

--- a/site/about.html
+++ b/site/about.html
@@ -7,7 +7,7 @@
   <meta name="description" content="About understand-quickly — README and design overview.">
   <meta name="theme-color" content="#0a0a0a">
 
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://looptech-ai.github.io https://raw.githubusercontent.com https://static.cloudflareinsights.com https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https:; frame-ancestors 'none'; base-uri 'self';">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/site/add.html
+++ b/site/add.html
@@ -7,6 +7,8 @@
   <meta name="description" content="Two-click registration for understand-quickly. Fill four fields, open a pre-filled GitHub issue, and the bot opens the PR.">
   <meta name="theme-color" content="#0a0a0a">
 
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://looptech-ai.github.io https://raw.githubusercontent.com https://api.github.com https://static.cloudflareinsights.com https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://github.com;">
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet"
@@ -63,27 +65,36 @@
             Format
             <span class="field-required" aria-hidden="true">*</span>
           </legend>
-          <p class="field-hint">Pick the producer that emits your knowledge graph.</p>
+          <p class="field-hint">
+            Pick the producer that emits your knowledge graph. Not sure which?
+            See the <a href="https://github.com/looptech-ai/understand-quickly/blob/main/docs/faq.md#whats-the-difference-between-the-formats-understand-anything1-gitnexus1-bundle1-" rel="noopener" target="_blank">format guide</a>
+            or pick <code>generic@1</code>.
+          </p>
           <div class="radio-list" role="radiogroup" aria-label="Graph format">
             <label class="radio-card">
               <input type="radio" name="format" value="understand-anything@1" required>
               <span class="radio-title"><code>understand-anything@1</code></span>
-              <span class="radio-desc">Knowledge graph from <a href="https://github.com/Lum1104/Understand-Anything" rel="noopener" target="_blank">Lum1104/Understand-Anything</a>.</span>
+              <span class="radio-desc">From <a href="https://github.com/Lum1104/Understand-Anything" rel="noopener" target="_blank">Lum1104/Understand-Anything</a>. <a href="./schemas/understand-anything@1.json" rel="noopener" target="_blank">View schema ↗</a></span>
             </label>
             <label class="radio-card">
               <input type="radio" name="format" value="gitnexus@1">
               <span class="radio-title"><code>gitnexus@1</code></span>
-              <span class="radio-desc">Knowledge graph from <a href="https://github.com/abhigyanpatwari/GitNexus" rel="noopener" target="_blank">abhigyanpatwari/GitNexus</a>.</span>
+              <span class="radio-desc">From <a href="https://github.com/abhigyanpatwari/GitNexus" rel="noopener" target="_blank">abhigyanpatwari/GitNexus</a>. <a href="./schemas/gitnexus@1.json" rel="noopener" target="_blank">View schema ↗</a></span>
             </label>
             <label class="radio-card">
               <input type="radio" name="format" value="code-review-graph@1">
               <span class="radio-title"><code>code-review-graph@1</code></span>
-              <span class="radio-desc">Knowledge graph from <a href="https://github.com/tirth8205/code-review-graph" rel="noopener" target="_blank">tirth8205/code-review-graph</a>.</span>
+              <span class="radio-desc">From <a href="https://github.com/tirth8205/code-review-graph" rel="noopener" target="_blank">tirth8205/code-review-graph</a>. <a href="./schemas/code-review-graph@1.json" rel="noopener" target="_blank">View schema ↗</a></span>
+            </label>
+            <label class="radio-card">
+              <input type="radio" name="format" value="bundle@1">
+              <span class="radio-title"><code>bundle@1</code></span>
+              <span class="radio-desc">Repo-context packers (<a href="https://github.com/yamadashy/repomix" rel="noopener" target="_blank">Repomix</a>, <a href="https://github.com/cyclotruc/gitingest" rel="noopener" target="_blank">gitingest</a>, <a href="https://github.com/kamilstanuch/codebase-digest" rel="noopener" target="_blank">codebase-digest</a>). <a href="./schemas/bundle@1.json" rel="noopener" target="_blank">View schema ↗</a></span>
             </label>
             <label class="radio-card">
               <input type="radio" name="format" value="generic@1">
               <span class="radio-title"><code>generic@1</code></span>
-              <span class="radio-desc">Any <code>{nodes, edges}</code> graph (escape hatch).</span>
+              <span class="radio-desc">Any <code>{nodes, edges}</code> graph — escape hatch when no first-class format fits. <a href="./schemas/generic@1.json" rel="noopener" target="_blank">View schema ↗</a></span>
             </label>
           </div>
           <p class="field-error" id="err-format" hidden></p>
@@ -181,28 +192,59 @@
       </form>
 
       <section class="faq">
-        <h2>FAQ</h2>
+        <h2>Common questions</h2>
         <details>
-          <summary>Don&rsquo;t have a graph yet?</summary>
+          <summary>I don&rsquo;t have a graph yet &mdash; what do I run?</summary>
           <p>
-            Run any of the supported tools first &mdash; see
-            <a href="./about.html#supported-formats" rel="noopener">Supported formats</a>
-            on the README for setup links and example outputs.
+            Each format has a producer tool linked next to it above. Run that tool against your
+            repo, commit the output, then come back. The
+            <a href="https://github.com/looptech-ai/understand-quickly/blob/main/docs/faq.md" rel="noopener" target="_blank">FAQ</a>
+            walks through this in plain language.
           </p>
         </details>
         <details>
-          <summary>Don&rsquo;t want to open a GitHub issue?</summary>
+          <summary>I&rsquo;m not sure which format to pick.</summary>
+          <p>
+            If your repo is a generic codebase, pick <code>generic@1</code> &mdash; it accepts any
+            <code>{nodes, edges}</code> shape and a maintainer can re-tag you to a stricter format
+            later if it fits. If you used a specific tool (Repomix, gitingest, GitNexus, etc.),
+            pick the matching format above. Worst case, ask in the
+            <a href="https://github.com/looptech-ai/understand-quickly/discussions" rel="noopener" target="_blank">Discussions</a>.
+          </p>
+        </details>
+        <details>
+          <summary>How long until my entry shows up?</summary>
+          <p>
+            <strong>Verified publishers</strong>: same-day, auto-merged after CI passes.
+            <strong>First-time contributors</strong>: 24&ndash;48h while a maintainer reviews.
+            After merge, the registry resyncs your entry within a few minutes.
+          </p>
+        </details>
+        <details>
+          <summary>I don&rsquo;t want to open a GitHub issue.</summary>
           <p>
             Click <strong>Copy as JSON for direct PR</strong> above, then open a PR yourself per
             <a href="https://github.com/looptech-ai/understand-quickly/blob/main/CONTRIBUTING.md" rel="noopener" target="_blank">CONTRIBUTING.md</a>.
-            A direct PR is usually faster than an issue.
+            Direct PRs are usually faster than issues.
           </p>
         </details>
         <details>
-          <summary>Why a bot, not direct write access?</summary>
+          <summary>Why a bot review, not direct write access?</summary>
           <p>
-            Same gate as awesome-lists: a maintainer review on every entry keeps quality high and the
-            registry trustworthy for downstream agents. The bot just removes the typing.
+            Same gate as awesome-lists: a maintainer review on every entry keeps quality high and
+            the registry trustworthy for downstream agents. The bot just removes the typing &mdash; it
+            doesn&rsquo;t skip review. Verified publishers (allowlisted maintainers) skip the review for
+            registry-only PRs.
+          </p>
+        </details>
+        <details>
+          <summary>What rights am I granting by submitting?</summary>
+          <p>
+            By submitting an entry you accept the
+            <a href="https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md" rel="noopener" target="_blank">Data License 1.0</a>:
+            anyone can use the registry (including for AI training); LoopTech.AI and Alex
+            Macdonald-Smith get a perpetual, sublicensable right to use submitted data; that grant
+            travels with any fork. Don&rsquo;t submit content you don&rsquo;t have rights to share.
           </p>
         </details>
       </section>
@@ -210,11 +252,15 @@
   </div>
 
   <footer class="site-footer" role="contentinfo">
-    <span>MIT</span>
+    <a href="https://github.com/looptech-ai/understand-quickly/blob/main/LICENSE" rel="noopener">Apache 2.0</a>
+    <span>·</span>
+    <a href="https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md" rel="noopener">Data License 1.0</a>
     <span>·</span>
     <a href="https://github.com/looptech-ai/understand-quickly" rel="noopener">source</a>
     <span>·</span>
-    <a href="./schemas/">spec</a>
+    <a href="./schemas/meta.schema.json" rel="noopener">spec</a>
+    <span>·</span>
+    <a href="https://github.com/looptech-ai/understand-quickly/blob/main/docs/faq.md" rel="noopener">FAQ</a>
   </footer>
 
   <script type="module" src="./add.js?v=20260507h"></script>

--- a/site/app.js
+++ b/site/app.js
@@ -1777,6 +1777,13 @@ function applyDeeplinkToViewer(viewer, dl) {
 // ---------- wiring ----------
 
 function bindToolbar() {
+  const form = document.getElementById('toolbar');
+  if (form) {
+    // Prevent the default form submit (which would reload the page when a
+    // user presses Enter). The previous inline onsubmit attribute conflicts
+    // with the strict CSP and so was moved here.
+    form.addEventListener('submit', (ev) => ev.preventDefault());
+  }
   const q = document.getElementById('q');
   q.addEventListener('input', () => {
     state.q = q.value;

--- a/site/index.html
+++ b/site/index.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
 
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://looptech-ai.github.io https://raw.githubusercontent.com https://api.github.com https://static.cloudflareinsights.com https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https:; frame-ancestors 'none'; base-uri 'self';">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -24,7 +24,7 @@
       <a class="brand" href="./" aria-label="understand-quickly home">
         <span class="brand-mark"><span class="brand-emoji" aria-hidden="true">&#129504;</span>understand-quickly</span>
       </a>
-      <form class="topbar-search" id="toolbar" role="search" aria-label="Search" onsubmit="return false;">
+      <form class="topbar-search" id="toolbar" role="search" aria-label="Search">
         <label class="visually-hidden" for="q">Search</label>
         <input
           type="search"

--- a/site/index.html
+++ b/site/index.html
@@ -9,6 +9,8 @@
   <meta http-equiv="Cache-Control" content="no-cache, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
 
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://looptech-ai.github.io https://raw.githubusercontent.com https://api.github.com https://static.cloudflareinsights.com https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self';">
+
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet"
@@ -202,11 +204,15 @@
     </div>
 
     <footer class="site-footer" role="contentinfo">
-      <span>MIT</span>
+      <a href="https://github.com/looptech-ai/understand-quickly/blob/main/LICENSE" rel="noopener">Apache 2.0</a>
+      <span>·</span>
+      <a href="https://github.com/looptech-ai/understand-quickly/blob/main/DATA-LICENSE.md" rel="noopener">Data License 1.0</a>
       <span>·</span>
       <a href="https://github.com/looptech-ai/understand-quickly" rel="noopener">source</a>
       <span>·</span>
-      <a href="./schemas/">spec</a>
+      <a href="./schemas/meta.schema.json" rel="noopener">spec</a>
+      <span>·</span>
+      <a href="https://github.com/looptech-ai/understand-quickly/blob/main/docs/faq.md" rel="noopener">FAQ</a>
     </footer>
 
     <div id="diag" hidden></div>


### PR DESCRIPTION
## Summary

Two-commit sweep across licensing, security, hardness, efficiency, UX, and integration extension. Tests: **143/143 green** (91 registry + 27 MCP + 25 CLI).

### Licensing (irreversible — please read first)
- **Code:** MIT → **Apache 2.0**, joint copyright **Alex Macdonald-Smith and LoopTech.AI**, NOTICE added.
- **Data:** new **Understand-Quickly Data License 1.0** (`DATA-LICENSE.md`). Permissive use rights for everyone (incl. AI/ML training); a perpetual, sublicensable back-grant to LoopTech.AI + Alex from every User and Forker; producer submissions carry an explicit ingestion grant; the back-grant travels with any fork.
- `cli/`, `mcp/`, root `package.json` license fields updated; `CONTRIBUTING.md` references DCO + DATA-LICENSE.
- ⚠️ **Recommend a lawyer review the `DATA-LICENSE.md` text before merging.** It's enforceable language, not a README.

### Security + hardness (14 fixes)
- **MCP**: SSRF guard on graph fetches (loopback, RFC1918, link-local incl. `169.254.169.254`, ULA IPv6, `*.internal/*.local`, https-only). Schema-version assertion. Stale-cache fallback on 5xx.
- **Sync**: atomic registry write (tmp + rename), deterministic id-sort before write, wrapped legacy JSON parse, drift errors logged to stderr.
- **Validate**: `CHANGED_IDS` validated against owner/repo regex with 1000-cap. Ajv `strict: 'log'`. Format-specific error context.
- **Schemas**: `meta.schema.json` `owner`/`repo` tightened to `^[A-Za-z0-9_.-]+$` with 100-char cap.
- **Aggregator**: `AbortController` 30s timeout, `Content-Length` + post-buffer cap at 50MB, label tokenization cap.
- **Issue parser**: ReDoS-prone regex replaced with O(n) split parser; 200k-char body cap.
- **README rendering**: description sanitization (HTML-escape, strip dangerous URL schemes).
- **Site**: CSP `<meta>` on all three pages; locks scripts to self + Cloudflare beacon, blocks `frame-ancestors`.

### Efficiency
- Memoized Ajv compilation + format schemas — main test suite **4.0s → 2.7s (~32% faster)**.
- Parallel aggregate fetches via bounded worker pool (concurrency=6) with deterministic serial fold.

### UX for non-technical users
- New plain-English **`docs/faq.md`** (what is this / what's a knowledge graph / what rights am I granting / glossary).
- README "New here?" intro section.
- Status legend gains "What to do" column per status.
- `add-repo.yml` issue template rewritten: friendly intro, faster-paths callout, `bundle@1` in dropdown, per-field hints, "what happens next" footer.
- Wizard (`add.html`): `bundle@1` selectable, "View schema ↗" links per format, expanded FAQ.
- CLI: top-level help shows examples + FAQ link; explicit Node-20 preflight; error path links wizard/FAQ/issue tracker.
- All site footers: Apache 2.0 + Data License 1.0 + FAQ + correct spec link.

### Integration extension (8 producer PR drafts)
- Wave 1 (no schema dep): graphify, codebase-memory-mcp, deepwiki-open
- Wave 2 (bundle@1 / generic@1): repomix, gitingest, codebase-digest, pocketflow-tutorial-codebase-knowledge, opendeepwiki

### GitHub repo polish
- New CodeQL workflow scanning JS/TS on push, PRs, and weekly.
- New FUNDING.yml.
- Dependabot: `/cli` directory now scanned (was missed); dev deps grouped; per-ecosystem commit prefixes.

## Test plan

- [x] `npm test` (registry) — 91/91
- [x] `npm test --prefix mcp` — 27/27
- [x] `npm test --prefix cli` — 25/25
- [ ] Site CSP doesn't break vis-network / Cloudflare beacon — verify with Playwright after merge
- [ ] Pages deploy preview renders correctly with new CSP

## Notes

- This is a large multi-axis PR by design (the user requested a single combined commit). Happy to split if reviewers prefer per-axis commits in a follow-up.
- The deferred review items (parallel sync fetches, HTTP Agent pooling, vis-network slimming, CHANGED_IDS in validate.yml, etc.) are tracked separately and not in this PR.

https://claude.ai/code/session_01PkkHiFCEmuNaymtGiH7Fkk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkkHiFCEmuNaymtGiH7Fkk)_